### PR TITLE
refactor : Friend 레이어 간 구분

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id "org.sonarqube" version "2.5"
 }
 
 group = 'com.efub'

--- a/src/main/java/com/efub/lakkulakku/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/controller/CommentController.java
@@ -4,12 +4,14 @@ import com.efub.lakkulakku.domain.comment.dto.CommentDeleteReqDto;
 import com.efub.lakkulakku.domain.comment.dto.CommentReqDto;
 import com.efub.lakkulakku.domain.comment.dto.CommentResDto;
 import com.efub.lakkulakku.domain.comment.dto.CommentUpdateResDto;
+import com.efub.lakkulakku.domain.comment.entity.Comment;
 import com.efub.lakkulakku.domain.comment.exception.ParentNotFoundException;
 import com.efub.lakkulakku.domain.comment.exception.UnauthorizedException;
 import com.efub.lakkulakku.domain.comment.repository.CommentRepository;
 import com.efub.lakkulakku.domain.comment.service.CommentService;
 import com.efub.lakkulakku.domain.diary.exception.DiaryNotFoundException;
 import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
+import com.efub.lakkulakku.domain.diary.service.DiaryService;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import com.efub.lakkulakku.domain.users.service.AuthUsers;
 import lombok.RequiredArgsConstructor;
@@ -26,20 +28,15 @@ import static com.efub.lakkulakku.global.constant.ResponseConstant.COMMENT_DELET
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/diaries")
 public class CommentController {
-
 	private final CommentService commentService;
 	private final CommentRepository commentRepository;
-	private final DiaryRepository diaryRepository;
+	private final DiaryService diaryService;
 
 	@PostMapping("/{date}/comments")
 	public ResponseEntity<?> commentAdd(@AuthUsers Users user, @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date, @RequestBody CommentReqDto commentReqDto) {
 
-		if (!diaryRepository.existsByDate(date))
+		if (!diaryService.existsByDate(date))
 			throw new DiaryNotFoundException();
-		if (commentReqDto.getParentId() != null) {
-			commentRepository.findById(commentReqDto.getParentId())
-					.orElseThrow(() -> new ParentNotFoundException());
-		}
 
 		CommentResDto commentResDto = commentService.addComment(user, date, commentReqDto);
 

--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentMapper.java
@@ -29,8 +29,8 @@ public class CommentMapper {
 		}
 
 		return CommentResDto.builder()
-				.id(entity.getId())
-				.userId(entity.getUsers().getId())
+				.id(entity.getCommentId())
+				.userId(entity.getUsers().getUserId())
 				.profileImageUrl(profileImageUrl)
 				.nickname(entity.getUsers().getNickname())
 				.parentId(entity.getParentId())
@@ -43,10 +43,10 @@ public class CommentMapper {
 	public Comment checkIsEntity(Diary diary, CommentResDto dto) {
 		Comment comment;
 
-		if (dto.getId() == null)
+		if (dto.getCommentId() == null)
 			comment = toEntity(diary, dto);
 		else
-			comment = commentRepository.findById(dto.getId()).orElseThrow(CommentNotFoundException::new);
+			comment = commentRepository.findById(dto.getCommentId()).orElseThrow(CommentNotFoundException::new);
 
 		return comment;
 	}
@@ -55,7 +55,7 @@ public class CommentMapper {
 		if (diary == null || dto == null)
 			return null;
 
-		Users users = usersRepository.findById(dto.getId()).orElseThrow(UserNotFoundException::new);
+		Users users = usersRepository.findById(dto.getUserId()).orElseThrow(UserNotFoundException::new);
 
 		return Comment.builder()
 				.diary(diary)

--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentReqDto.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 public class CommentReqDto {
-	private UUID id;
+	private UUID commentId;
 
 	private UUID diaryId;
 	private String content;
@@ -17,8 +17,8 @@ public class CommentReqDto {
 	private UUID parentId;
 
 	@Builder
-	public CommentReqDto(UUID id, UUID diaryId, String content, boolean isSecret, UUID parentId) {
-		this.id = id;
+	public CommentReqDto(UUID commentId, UUID diaryId, String content, boolean isSecret, UUID parentId) {
+		this.commentId = commentId;
 		this.diaryId = diaryId;
 		this.content = content;
 		this.isSecret = isSecret;

--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentReqDto.java
@@ -9,8 +9,8 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 public class CommentReqDto {
-
 	private UUID id;
+
 	private UUID diaryId;
 	private String content;
 	private boolean isSecret;
@@ -18,7 +18,6 @@ public class CommentReqDto {
 
 	@Builder
 	public CommentReqDto(UUID id, UUID diaryId, String content, boolean isSecret, UUID parentId) {
-
 		this.id = id;
 		this.diaryId = diaryId;
 		this.content = content;

--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentResDto.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class CommentResDto {
 
-	private UUID id;
+	private UUID commentId;
 	private UUID userId;
 	private String profileImageUrl;
 	private String nickname;
@@ -24,7 +24,7 @@ public class CommentResDto {
 	@Builder
 	public CommentResDto(UUID id, UUID userId, String profileImageUrl, String nickname, UUID parentId, String content,
 						 Boolean isSecret, LocalDateTime createdOn, String message) {
-		this.id = id;
+		this.commentId = commentId;
 		this.userId = userId;
 		this.profileImageUrl = profileImageUrl;
 		this.nickname = nickname;

--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentUpdateResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentUpdateResDto.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class CommentUpdateResDto {
 
-	private UUID id;
+	private UUID commentId;
 	private UUID userId;
 	private String profileImageUrl;
 	private String nickname;
@@ -23,7 +23,7 @@ public class CommentUpdateResDto {
 	@Builder
 	public CommentUpdateResDto(UUID id, UUID userId, String profileImageUrl, String nickname, UUID parentId, String content,
 						 Boolean isSecret, LocalDateTime modifiedOn) {
-		this.id = id;
+		this.commentId = id;
 		this.userId = userId;
 		this.profileImageUrl = profileImageUrl;
 		this.nickname = nickname;

--- a/src/main/java/com/efub/lakkulakku/domain/comment/entity/Comment.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/entity/Comment.java
@@ -24,7 +24,7 @@ public class Comment extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID commentId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "users_id")

--- a/src/main/java/com/efub/lakkulakku/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.efub.lakkulakku.domain.comment.repository;
 
 import com.efub.lakkulakku.domain.comment.entity.Comment;
+import com.efub.lakkulakku.domain.diary.entity.Diary;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -18,5 +19,5 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
 	Optional<Comment> findByParentId(UUID parentId);
 
-	int countByDiaryId(UUID id);
+	int countByDiary(Diary diary);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/comment/service/CommentService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.efub.lakkulakku.domain.comment.dto.CommentResDto;
 import com.efub.lakkulakku.domain.comment.dto.CommentUpdateResDto;
 import com.efub.lakkulakku.domain.comment.entity.Comment;
 import com.efub.lakkulakku.domain.comment.exception.CommentNotFoundException;
+import com.efub.lakkulakku.domain.comment.exception.ParentNotFoundException;
 import com.efub.lakkulakku.domain.comment.exception.UnauthorizedException;
 import com.efub.lakkulakku.domain.comment.repository.CommentRepository;
 import com.efub.lakkulakku.domain.diary.entity.Diary;
@@ -17,11 +18,13 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+import java.util.UUID;
 
 import static com.efub.lakkulakku.global.constant.ResponseConstant.COMMENT_ADD_SUCCESS;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommentService {
 
 	private final CommentRepository commentRepository;
@@ -29,7 +32,6 @@ public class CommentService {
 
 	private final ApplicationEventPublisher eventPublisher;
 
-	@Transactional
 	public CommentResDto addComment(Users user, LocalDate date, CommentReqDto commentReqDto) {
 
 		Diary diary = diaryRepository.findById(commentReqDto.getDiaryId()).get();
@@ -66,7 +68,7 @@ public class CommentService {
 
 	}
 
-	@Transactional
+
 	public void removeComment(Users user, LocalDate date, CommentDeleteReqDto commentDeleteReqDto) {
 
 		if (!commentRepository.findById(commentDeleteReqDto.getId()).get().getUsers().getId().equals(user.getId()))
@@ -79,7 +81,7 @@ public class CommentService {
 
 	}
 
-	@Transactional
+
 	public CommentUpdateResDto update(Users user, LocalDate date, CommentReqDto commentReqDto) {
 
 		if (!commentRepository.findById(commentReqDto.getId()).get().getUsers().getId().equals(user.getId()))
@@ -107,7 +109,7 @@ public class CommentService {
 
 	}
 
-	@Transactional
+
 	public String checkProfileImageUrl(Users user) {
 		if (user.getProfile() == null || user.getProfile().getFile() == null) {
 			return null;
@@ -119,5 +121,10 @@ public class CommentService {
 
 	private void notifyInfo(Comment comment, String notiType) {
 		comment.publishEvent(eventPublisher, notiType);
+	}
+
+	public Comment findById(UUID commentId){
+		return commentRepository.findById(commentId)
+				.orElseThrow(() -> new ParentNotFoundException());
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/comment/service/CommentService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/service/CommentService.java
@@ -50,13 +50,13 @@ public class CommentService {
 		if (commentReqDto.getParentId() != null) {
 			type = "대댓글";
 		}
-		if (!user.getId().equals(diary.getUser().getId())) {
+		if (!user.getUserId().equals(diary.getUser().getUserId())) {
 			notifyInfo(comment, type);
 		}
 
 		return CommentResDto.builder()
-				.id(comment.getId())
-				.userId(comment.getUsers().getId())
+				.id(comment.getCommentId())
+				.userId(comment.getUsers().getUserId())
 				.profileImageUrl(checkProfileImageUrl(user))
 				.nickname(user.getNickname())
 				.parentId(comment.getParentId())
@@ -71,7 +71,7 @@ public class CommentService {
 
 	public void removeComment(Users user, LocalDate date, CommentDeleteReqDto commentDeleteReqDto) {
 
-		if (!commentRepository.findById(commentDeleteReqDto.getId()).get().getUsers().getId().equals(user.getId()))
+		if (!commentRepository.findById(commentDeleteReqDto.getId()).get().getUsers().getUserId().equals(user.getUserId()))
 			throw new UnauthorizedException();
 
 		if (!commentRepository.existsById(commentDeleteReqDto.getId()))
@@ -84,21 +84,21 @@ public class CommentService {
 
 	public CommentUpdateResDto update(Users user, LocalDate date, CommentReqDto commentReqDto) {
 
-		if (!commentRepository.findById(commentReqDto.getId()).get().getUsers().getId().equals(user.getId()))
+		if (!commentRepository.findById(commentReqDto.getCommentId()).get().getUsers().getUserId().equals(user.getUserId()))
 			throw new UnauthorizedException();
 
-		if (!commentRepository.existsById(commentReqDto.getId()))
+		if (!commentRepository.existsById(commentReqDto.getCommentId()))
 			throw new CommentNotFoundException();
 
-		Comment comment = commentRepository.findById(commentReqDto.getId()).orElseThrow();
+		Comment comment = commentRepository.findById(commentReqDto.getCommentId()).orElseThrow();
 
 		comment.update(commentReqDto.getContent());
 
 		commentRepository.save(comment);
 
 		return CommentUpdateResDto.builder()
-				.id(comment.getId())
-				.userId(comment.getUsers().getId())
+				.id(comment.getCommentId())
+				.userId(comment.getUsers().getUserId())
 				.profileImageUrl(checkProfileImageUrl(user))
 				.nickname(user.getNickname())
 				.parentId(comment.getParentId())

--- a/src/main/java/com/efub/lakkulakku/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/controller/DiaryController.java
@@ -14,6 +14,7 @@ import com.efub.lakkulakku.domain.users.entity.Users;
 import com.efub.lakkulakku.domain.users.exception.UserNotFoundException;
 import com.efub.lakkulakku.domain.users.repository.UsersRepository;
 import com.efub.lakkulakku.domain.users.service.AuthUsers;
+import com.efub.lakkulakku.domain.users.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
@@ -35,20 +36,18 @@ import static com.efub.lakkulakku.global.constant.ResponseConstant.*;
 public class DiaryController {
 
 	private final DiaryService diaryService;
-	private final DiaryRepository diaryRepository;
-	private final UsersRepository usersRepository;
+	private final UsersService usersService;
 
 	@GetMapping("/{date}")
 	public ResponseEntity<DiaryLookupResDto> getDiaryByDate(@PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
 															@RequestParam String nickname, @AuthUsers Users loginUser) {
-		Users user = usersRepository.findByNickname(nickname)
-				.orElseThrow(UserNotFoundException::new);
+		Users user = usersService.findByNickname(nickname);
 		diaryService.checkDiaryIsInDate(date);
-		if (!diaryRepository.existsByDate(date))
+		if (!diaryService.existsByDate(date))
 			return ResponseEntity.ok()
 					.body(new DiaryLookupResDto(null, null, null, null, null, null));
 
-		Diary diary = diaryRepository.findByDateAndUserId(date, user.getId()).orElseThrow(DiaryNotFoundException::new);
+		Diary diary = diaryService.findByDateAndUser(date, user);
 
 		// 로그인한 유저와 다이어리 작성한 유저가 같은 경우에만 조회수 증가
 		if (!loginUser.getNickname().equals(nickname))
@@ -61,16 +60,14 @@ public class DiaryController {
 	@GetMapping("/comments/{date}")
 	public List<CommentResDto> getDiaryCommentsByDate(@PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
 													  @RequestParam String nickname) {
-		Users user = usersRepository.findByNickname(nickname)
-				.orElseThrow(UserNotFoundException::new);
+		Users user = usersService.findByNickname(nickname);
 		diaryService.checkDiaryIsInDate(date);
 
-		if (!diaryRepository.existsByDate(date)) {
+		if (!diaryService.existsByDate(date)) {
 			return new ArrayList<>();
 		}
 
-		Diary diary = diaryRepository.findByDateAndUserId(date, user.getId())
-				.orElseThrow(DiaryNotFoundException::new);
+		Diary diary = diaryService.findByDateAndUser(date, user);
 		return diaryService.getDiaryComments(diary);
 	}
 
@@ -78,19 +75,13 @@ public class DiaryController {
 	public ResponseEntity<DiaryMessageResDto> createDiary(@AuthUsers Users user,
 														  @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 		diaryService.checkDiaryIsInDate(date);
-
-		if(diaryRepository.existsByDateAndUserId(date, user.getId()))
-			throw new DuplicateDiaryException();
 		diaryService.createDiary(user, date);
 		return ResponseEntity.ok().body(new DiaryMessageResDto(date + DIARY_CREATE_SUCCESS));
 	}
 
 	@DeleteMapping("/{date}")
 	public ResponseEntity<DiaryMessageResDto> deleteDiary(@AuthUsers Users user, @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-
-		Diary diary = diaryRepository.findByDateAndUserId(date, user.getId())
-				.orElseThrow(DiaryNotFoundException::new);
-		diaryRepository.delete(diary);
+		diaryService.delete(date, user);
 		return ResponseEntity.ok().body(new DiaryMessageResDto(date + DIARY_DELETE_SUCCESS));
 	}
 
@@ -105,7 +96,7 @@ public class DiaryController {
 				.multipartFileList(files)
 				.diaryLookupReqDto(diaryLookupReqDto)
 				.build();
-		diaryService.saveDiary(date, diarySaveReqDto);
+		diaryService.saveDiary(date, user, diarySaveReqDto);
 		return ResponseEntity.ok().body(new DiaryMessageResDto(date + DIARY_UPDATE_SUCCESS));
 	}
 
@@ -120,7 +111,7 @@ public class DiaryController {
 				.multipartFileList(files)
 				.diaryLookupReqDto(diaryLookupReqDto)
 				.build();
-		diaryService.updateDiary(date, diarySaveReqDto);
+		diaryService.updateDiary(date, user, diarySaveReqDto);
 		return ResponseEntity.ok().body(new DiaryMessageResDto(date + DIARY_UPDATE_SUCCESS));
 	}
 

--- a/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryHomeMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryHomeMapper.java
@@ -14,7 +14,7 @@ public class DiaryHomeMapper {
 			return null;
 
 		return DiaryHomeResDto.builder()
-				.id(entity.getId())
+				.id(entity.getDiaryId())
 				.title(entity.getTitle())
 				.titleEmoji(entity.getTitleEmoji())
 				.date(entity.getDate())

--- a/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryMapper.java
@@ -45,7 +45,7 @@ public class DiaryMapper {
 	public DiaryResDto toDiaryResDto(Diary entity) {
 
 		return DiaryResDto.builder()
-				.id(entity.getId())
+				.id(entity.getDiaryId())
 				.userId(entity.getUser().getId())
 				.date(entity.getDate())
 				.title(entity.getTitle())

--- a/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryMapper.java
@@ -46,11 +46,11 @@ public class DiaryMapper {
 
 		return DiaryResDto.builder()
 				.id(entity.getDiaryId())
-				.userId(entity.getUser().getId())
+				.userId(entity.getUser().getUserId())
 				.date(entity.getDate())
 				.title(entity.getTitle())
 				.titleEmoji(entity.getTitleEmoji())
-				.templateId(entity.getTemplate().getId())
+				.templateId(entity.getTemplate().getTemplateId())
 				.cntComment(entity.getCntComment())
 				.cntLike(entity.getCntLike())
 				.cntView(entity.getCntView())

--- a/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
@@ -32,7 +32,7 @@ public class Diary extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID diaryId;
 
 	@ManyToOne
 	@OnDelete(action = OnDeleteAction.CASCADE)
@@ -138,5 +138,8 @@ public class Diary extends BaseTimeEntity {
 
 	public void addViewCount() {
 		this.cntView++;
+	}
+	public void setDaryId(UUID diaryId){
+		this.diaryId = diaryId;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
@@ -96,6 +96,7 @@ public class Diary extends BaseTimeEntity {
 		this.likes = likes;
 		this.texts = texts;
 		this.stickers = stickers;
+
 	}
 
 	public void setTemplate(Template template) {

--- a/src/main/java/com/efub/lakkulakku/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/repository/DiaryRepository.java
@@ -21,10 +21,10 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 	List<Diary> findUsersDiaryByYearAndMonth(@Param("userId") UUID userId, @Param("year") String year, @Param("month") String month);
 
 
-	boolean existsByDateAndUserId(LocalDate date, UUID userId);
+	boolean existsByDateAndUser(LocalDate date, Users user);
 
 	Optional<Diary> findByDate(LocalDate date);
-	Optional<Diary> findByDateAndUserId(LocalDate date, UUID userId);
+	Optional<Diary> findByDateAndUser(LocalDate date, Users user);
 	List<Diary> findByUser(Users users);
 
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/repository/DiaryRepository.java
@@ -26,4 +26,5 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 	Optional<Diary> findByDate(LocalDate date);
 	Optional<Diary> findByDateAndUserId(LocalDate date, UUID userId);
 	List<Diary> findByUser(Users users);
+
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
@@ -49,7 +49,7 @@ public class DiaryService {
 	}
 
 	public Diary updateDiaryCntCommentAndCntLikes(Diary diary) {
-		int cntComment = commentRepository.countByDiaryId(diary.getId());
+		int cntComment = commentRepository.countByDiaryId(diary.getDiaryId());
 		//int cntLike = likesRepository.countByDiaryId(diary.getId());
 		diary.setCntComment(cntComment);
 		//diary.setCntLike(cntLike);

--- a/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
@@ -9,6 +9,7 @@ import com.efub.lakkulakku.domain.diary.dto.DiarySaveReqDto;
 import com.efub.lakkulakku.domain.diary.entity.Diary;
 import com.efub.lakkulakku.domain.diary.exception.BadDateRequestException;
 import com.efub.lakkulakku.domain.diary.exception.DiaryNotFoundException;
+import com.efub.lakkulakku.domain.diary.exception.DuplicateDiaryException;
 import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
 import com.efub.lakkulakku.domain.likes.repository.LikesRepository;
 import com.efub.lakkulakku.domain.template.entity.Template;
@@ -16,17 +17,20 @@ import com.efub.lakkulakku.domain.template.repository.TemplateRepository;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
+
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DiaryService {
 
 	private final DiaryRepository diaryRepository;
@@ -66,8 +70,9 @@ public class DiaryService {
 		return diary.getComments().stream().filter(Objects::nonNull).map(commentMapper::toCommentResDto).collect(Collectors.toList());
 	}
 
-	@Transactional
 	public void createDiary(Users user, LocalDate diaryDate) {
+		if(existsByDateAndUserId(diaryDate, user))
+			throw new DuplicateDiaryException();
 		Diary diary = Diary.builder()
 				.user(user)
 				.date(diaryDate)
@@ -88,25 +93,52 @@ public class DiaryService {
 		templateRepository.save(template);
 	}
 
-	@Transactional
-	public void saveDiary(LocalDate date, DiarySaveReqDto dto) throws IOException {
-		Diary diary = diaryRepository.findByDate(date)
-				.orElseThrow(DiaryNotFoundException::new);
+	public void saveDiary(LocalDate date, Users user, DiarySaveReqDto dto) throws IOException {
+		Diary diary = findByDateAndUser(date, user);
 		Diary savedDiary = diaryMapper.saveDiary(diary, dto);
-		diaryRepository.save(savedDiary);
+		save(savedDiary);
 	}
 
-	@Transactional
-	public void updateDiary(LocalDate date, DiarySaveReqDto dto) throws IOException {
-		Diary diary = diaryRepository.findByDate(date)
-				.orElseThrow(DiaryNotFoundException::new);
+	public void save(Diary diary){
+		diaryRepository.save(diary);
+	}
+
+	public void updateDiary(LocalDate date, Users user, DiarySaveReqDto dto) throws IOException {
+		Diary diary = findByDateAndUser(date, user);
 		Diary updatedDiary = diaryMapper.updateDiary(diary, dto);
 		diaryRepository.save(updatedDiary);
 	}
 
-	@Transactional
 	public void deleteAllDiary(Users users){
 		List<Diary> diaryList = diaryRepository.findByUser(users);
 		diaryRepository.deleteAll(diaryList);
 	}
+
+	public void delete(LocalDate date, Users users){
+		Diary diary = findByDateAndUser(date, users);
+		diaryRepository.delete(diary);
+	}
+
+	@Transactional(readOnly = true)
+	public Diary findById(UUID postId){
+		return diaryRepository.findById(postId)
+				.orElseThrow((DiaryNotFoundException::new));
+	}
+
+	@Transactional(readOnly = true)
+	public Diary findByDateAndUser(LocalDate date, Users users){
+		return diaryRepository.findByDateAndUserId(date, users.getId())
+				.orElseThrow((DiaryNotFoundException::new));
+	}
+
+	@Transactional(readOnly = true)
+	public boolean existsByDateAndUserId(LocalDate diaryDate, Users user){
+		return diaryRepository.existsByDateAndUserId(diaryDate, user.getId());
+	}
+
+	@Transactional(readOnly = true)
+	public boolean existsByDate(LocalDate date){
+		return diaryRepository.existsByDate(date);
+	}
+
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
@@ -49,7 +49,7 @@ public class DiaryService {
 	}
 
 	public Diary updateDiaryCntCommentAndCntLikes(Diary diary) {
-		int cntComment = commentRepository.countByDiaryId(diary.getDiaryId());
+		int cntComment = commentRepository.countByDiary(diary);
 		//int cntLike = likesRepository.countByDiaryId(diary.getId());
 		diary.setCntComment(cntComment);
 		//diary.setCntLike(cntLike);
@@ -127,13 +127,13 @@ public class DiaryService {
 
 	@Transactional(readOnly = true)
 	public Diary findByDateAndUser(LocalDate date, Users users){
-		return diaryRepository.findByDateAndUserId(date, users.getId())
+		return diaryRepository.findByDateAndUser(date, users)
 				.orElseThrow((DiaryNotFoundException::new));
 	}
 
 	@Transactional(readOnly = true)
 	public boolean existsByDateAndUserId(LocalDate diaryDate, Users user){
-		return diaryRepository.existsByDateAndUserId(diaryDate, user.getId());
+		return diaryRepository.existsByDateAndUser(diaryDate, user);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/efub/lakkulakku/domain/file/entity/File.java
+++ b/src/main/java/com/efub/lakkulakku/domain/file/entity/File.java
@@ -20,7 +20,7 @@ public class File extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID fileId;
 
 	@NotNull
 	private String filename;

--- a/src/main/java/com/efub/lakkulakku/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/file/repository/FileRepository.java
@@ -18,6 +18,6 @@ public interface FileRepository extends JpaRepository<File, UUID> {
 
     @Transactional
     @Modifying
-    @Query(value = "DELETE f FROM file f LEFT OUTER JOIN profile p ON f.id=p.profile_image_id WHERE p.users_id IS NULL AND f.url LIKE \"https://s3.ap-northeast-2.amazonaws.com/lakku-lakku.com/profile%\";", nativeQuery = true)
+    @Query(value = "DELETE f FROM file f LEFT OUTER JOIN profile p ON f.file_id=p.profile_image_id WHERE p.users_id IS NULL AND f.url LIKE \"https://s3.ap-northeast-2.amazonaws.com/lakku-lakku.com/profile%\";", nativeQuery = true)
     void deleteUnusedFiles();
 }

--- a/src/main/java/com/efub/lakkulakku/domain/friend/dto/FriendReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/dto/FriendReqDto.java
@@ -2,6 +2,7 @@ package com.efub.lakkulakku.domain.friend.dto;
 
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,4 +16,8 @@ public class FriendReqDto {
 	@NotBlank
 	private Long uid;
 
+	@Builder
+	public FriendReqDto(Long uid) {
+		this.uid = uid;
+	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/friend/entity/Friend.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/entity/Friend.java
@@ -24,7 +24,7 @@ public class Friend extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID friendId;
 
 	@ManyToOne()
 	//@OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/efub/lakkulakku/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/repository/FriendRepository.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, UUID> {
 
-	Optional<Friend> findById(UUID id);
+	Optional<Friend> findByFriendId(UUID id);
 	Optional<Users> findByUserId(Users userId);
 	Optional<Users> findByTargetId(Users targetId);
 	List<Friend> findAllByUserId(Users user);

--- a/src/main/java/com/efub/lakkulakku/domain/friend/service/FriendService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/service/FriendService.java
@@ -24,7 +24,6 @@ public class FriendService {
 	private final ApplicationEventPublisher eventPublisher;
 	private final FriendRepository friendRepository;
 	private final UsersRepository usersRepository;
-	private final NotificationRepository notificationRepository;
 
 	@Transactional
 	public void addFriend(FriendReqDto reqDto, Users user) {
@@ -76,10 +75,10 @@ public class FriendService {
 	public UUID isFriend(Users user, Users target) {
 		Optional<Friend> friend = friendRepository.findByUserIdAndTargetId(user, target);
 		if (friend.isPresent()) {
-			return friend.get().getId();
+			return friend.get().getFriendId();
 		} else {
 			friend = friendRepository.findByUserIdAndTargetId(target, user);
-			return friend.map(Friend::getId).orElse(null);
+			return friend.map(Friend::getFriendId).orElse(null);
 		}
 	}
 

--- a/src/main/java/com/efub/lakkulakku/domain/friend/service/FriendService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/service/FriendService.java
@@ -11,27 +11,30 @@ import com.efub.lakkulakku.domain.notification.entity.Notification;
 import com.efub.lakkulakku.domain.notification.repository.NotificationRepository;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.domain.users.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
+
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FriendService {
 	private final ApplicationEventPublisher eventPublisher;
 	private final FriendRepository friendRepository;
-	private final UsersRepository usersRepository;
+	private final UsersService usersService;
 
-	@Transactional
+
 	public void addFriend(FriendReqDto reqDto, Users user) {
 		if (Objects.equals(reqDto.getUid(), user.getUid())) {
 			throw new SelfFriendException();
 		}
 
-		Users targetUser = usersRepository.findByUid(reqDto.getUid()).orElseThrow(UserNotFoundException::new);
+		Users targetUser = usersService.findByUid(reqDto.getUid());
 		if (isFriend(user, targetUser) != null) {
 			throw new DuplicateFriendException();
 		} else {
@@ -44,10 +47,9 @@ public class FriendService {
 		}
 	}
 
-	@Transactional
 	public List<FriendResDto> getFriends(Users user) {
-		List<Friend> friends1 = friendRepository.findAllByUserId(user);
-		List<Friend> friends2 = friendRepository.findAllByTargetId(user);
+		List<Friend> friends1 = findAllByUserId(user);
+		List<Friend> friends2 = findAllByTargetId(user);
 		List<FriendResDto> friendList = new ArrayList<>();
 		for (Friend temp : friends1) {
 			Users one = temp.getTargetId();
@@ -66,12 +68,11 @@ public class FriendService {
 		return friendList;
 	}
 
-	@Transactional
 	public FriendResDto buildDto(Users user) {
 		return new FriendResDto(user);
 	}
 
-	@Transactional
+
 	public UUID isFriend(Users user, Users target) {
 		Optional<Friend> friend = friendRepository.findByUserIdAndTargetId(user, target);
 		if (friend.isPresent()) {
@@ -82,10 +83,9 @@ public class FriendService {
 		}
 	}
 
-	@Transactional
+
 	public void deleteFriend(FriendReqDto reqDto, Users user) {
-		Users delFriend = usersRepository.findByUid(reqDto.getUid())
-				.orElseThrow(UserNotFoundException::new);
+		Users delFriend = usersService.findByUid(reqDto.getUid());
 		UUID id = isFriend(user, delFriend);
 		friendRepository.deleteById(id);
 	}
@@ -94,12 +94,23 @@ public class FriendService {
 		friend.publishEvent(eventPublisher, notiType);
 	}
 
-	@Transactional
+
 	public void deleteAllFriend(Users users){
-		List<Friend> friendUserList = friendRepository.findAllByUserId(users);
-		List<Friend> friendTargetList = friendRepository.findAllByTargetId(users);
+		List<Friend> friendUserList = findAllByUserId(users);
+		List<Friend> friendTargetList = findAllByTargetId(users);
 
 		friendRepository.deleteAll(friendUserList);
 		friendRepository.deleteAll(friendTargetList);
 	}
+
+	@Transactional(readOnly = true)
+	public List<Friend> findAllByTargetId(Users targetUser){
+		return friendRepository.findAllByTargetId(targetUser);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Friend> findAllByUserId(Users user){
+		return friendRepository.findAllByUserId(user);
+	}
+
 }

--- a/src/main/java/com/efub/lakkulakku/domain/image/dto/ImageMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/image/dto/ImageMapper.java
@@ -30,7 +30,7 @@ public class ImageMapper {
 			return null;
 
 		return ImageResDto.builder()
-				.id(entity.getId())
+				.id(entity.getImageId())
 				.width(entity.getWidth())
 				.height(entity.getHeight())
 				.x(entity.getX())

--- a/src/main/java/com/efub/lakkulakku/domain/image/entity/Image.java
+++ b/src/main/java/com/efub/lakkulakku/domain/image/entity/Image.java
@@ -21,7 +21,7 @@ public class Image extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID imageId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "diary_id")

--- a/src/main/java/com/efub/lakkulakku/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/controller/LikesController.java
@@ -27,8 +27,6 @@ public class LikesController {
 	@PostMapping("/{date}/like")
 	public ResponseEntity<LikeClickResDto> likeClick(@AuthUsers Users user, @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date, @RequestBody LikeReqDto likeReqDto) {
 
-		if (!diaryRepository.existsByDate(date))
-			throw new DiaryNotFoundException();
 		LikeClickResDto likeClickResDto = likesService.clickLike(user, date, likeReqDto);
 		return new ResponseEntity<>(likeClickResDto, HttpStatus.OK);
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeClickResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeClickResDto.java
@@ -14,14 +14,15 @@ public class LikeClickResDto {
 	private LocalDateTime createdOn;
 	private UUID diaryId;
 	private String message;
-	private boolean isLike;
+	private Boolean isLike;
 
 	@Builder
-	public LikeClickResDto(UUID id, UUID diaryId, LocalDateTime createdOn, String message, boolean isLike) {
+	public LikeClickResDto(UUID id, UUID diaryId, LocalDateTime createdOn, String message, Boolean isLike) {
 		this.id = id;
 		this.diaryId = diaryId;
 		this.createdOn = createdOn;
 		this.message = message;
 		this.isLike = isLike;
 	}
+
 }

--- a/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeMapper.java
@@ -24,7 +24,7 @@ public class LikeMapper {
 		return LikeClickResDto.builder()
 				.id(entity.getId())
 				.createdOn(entity.getCreatedOn())
-				.diaryId(entity.getDiary().getId())
+				.diaryId(entity.getDiary().getDiaryId())
 				.isLike(entity.getIsLike())
 				.build();
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeMapper.java
@@ -22,7 +22,7 @@ public class LikeMapper {
 			return null;
 
 		return LikeClickResDto.builder()
-				.id(entity.getId())
+				.id(entity.getLikeId())
 				.createdOn(entity.getCreatedOn())
 				.diaryId(entity.getDiary().getDiaryId())
 				.isLike(entity.getIsLike())
@@ -37,8 +37,8 @@ public class LikeMapper {
 			profileImageUrl = null;
 		}
 		return LikeResDto.builder()
-				.id(entity.getId())
-				.userId(entity.getUsers().getId())
+				.id(entity.getLikeId())
+				.userId(entity.getUsers().getUserId())
 				.nickname(entity.getUsers().getNickname())
 				.profileImageUrl(entity.getUsers().getProfile().getFile().getUrl())
 				.createdOn(entity.getCreatedOn())

--- a/src/main/java/com/efub/lakkulakku/domain/likes/entity/Likes.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/entity/Likes.java
@@ -28,7 +28,7 @@ public class Likes extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID likeId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "diary_id")

--- a/src/main/java/com/efub/lakkulakku/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/repository/LikesRepository.java
@@ -19,5 +19,4 @@ public interface LikesRepository extends JpaRepository<Likes, UUID> {
 
 	boolean existsByDiaryAndUsers(Diary diary, Users user);
 
-	int countByDiaryId(UUID id);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/likes/service/LikesService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/service/LikesService.java
@@ -1,7 +1,10 @@
 package com.efub.lakkulakku.domain.likes.service;
 
+import com.efub.lakkulakku.domain.diary.dto.DiaryResDto;
 import com.efub.lakkulakku.domain.diary.entity.Diary;
+import com.efub.lakkulakku.domain.diary.exception.DiaryNotFoundException;
 import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
+import com.efub.lakkulakku.domain.diary.service.DiaryService;
 import com.efub.lakkulakku.domain.likes.dto.LikeClickResDto;
 import com.efub.lakkulakku.domain.likes.dto.LikeMapper;
 import com.efub.lakkulakku.domain.likes.dto.LikeReqDto;
@@ -11,9 +14,9 @@ import com.efub.lakkulakku.domain.users.entity.Users;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
-import javax.transaction.Transactional;
 import java.time.LocalDate;
 
 import static com.efub.lakkulakku.global.constant.ResponseConstant.LIKES_ADD_SUCCESS;
@@ -21,21 +24,23 @@ import static com.efub.lakkulakku.global.constant.ResponseConstant.LIKES_DELETE_
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class LikesService {
 
 	private final LikesRepository likesRepository;
 	private final LikeMapper likeMapper;
-	private final DiaryRepository diaryRepository;
+	private final DiaryService diaryService;
+
 	private final ApplicationEventPublisher eventPublisher;
 
-	@Transactional
+
 	public LikeClickResDto clickLike(Users user, LocalDate date, LikeReqDto likeReqDto) {
 
-		Diary diary = diaryRepository.findById(likeReqDto.getDiaryId()).get();
+		Diary diary = diaryService.findById(likeReqDto.getDiaryId());
 
 		Likes likes;
-		if (likesRepository.existsByDiaryAndUsers(diary, user)) {
-			likes = likesRepository.findByDiaryAndUsers(diary, user).orElseThrow();
+		if (existsByDiaryAndUsers(diary, user)) {
+			likes = findByDiaryAndUsers(diary, user);
 			likes.setIsLike();
 			likesRepository.save(likes);
 
@@ -51,11 +56,11 @@ public class LikesService {
 				notifyInfo(likes, "좋아요");
 			}
 			diary.setCntLike(diary.getCntLike() + 1);
-			diaryRepository.save(diary);
+			diaryService.save(diary);
 		}
 		else {
 			diary.setCntLike(diary.getCntLike() - 1);
-			diaryRepository.save(diary);
+			diaryService.save(diary);
 		}
 
 		return LikeClickResDto.builder()
@@ -66,6 +71,19 @@ public class LikesService {
 				.isLike(likes.getIsLike())
 				.build();
 	}
+
+	@Transactional(readOnly = true)
+	public Likes findByDiaryAndUsers(Diary diary, Users user){
+		return likesRepository.findByDiaryAndUsers(diary, user).orElseThrow((DiaryNotFoundException::new));
+	}
+
+	@Transactional(readOnly = true)
+	public boolean existsByDiaryAndUsers(Diary diary, Users user){
+		return likesRepository.existsByDiaryAndUsers(diary, user);
+	}
+
+
+
 
 	private void notifyInfo(Likes likes, String notiType) {
 		likes.publishEvent(eventPublisher, notiType);

--- a/src/main/java/com/efub/lakkulakku/domain/likes/service/LikesService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/service/LikesService.java
@@ -52,7 +52,7 @@ public class LikesService {
 		String message = likes.getIsLike() ? LIKES_ADD_SUCCESS : LIKES_DELETE_SUCCESS;
 
 		if (message.equals(LIKES_ADD_SUCCESS)) {
-			if (!user.getId().equals(diary.getUser().getId())) {
+			if (!user.getUserId().equals(diary.getUser().getUserId())) {
 				notifyInfo(likes, "좋아요");
 			}
 			diary.setCntLike(diary.getCntLike() + 1);
@@ -64,7 +64,7 @@ public class LikesService {
 		}
 
 		return LikeClickResDto.builder()
-				.id(likes.getId())
+				.id(likes.getLikeId())
 				.diaryId(likes.getDiary().getDiaryId())
 				.createdOn(likes.getCreatedOn())
 				.message(message)

--- a/src/main/java/com/efub/lakkulakku/domain/likes/service/LikesService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/service/LikesService.java
@@ -65,7 +65,7 @@ public class LikesService {
 
 		return LikeClickResDto.builder()
 				.id(likes.getId())
-				.diaryId(likes.getDiary().getId())
+				.diaryId(likes.getDiary().getDiaryId())
 				.createdOn(likes.getCreatedOn())
 				.message(message)
 				.isLike(likes.getIsLike())

--- a/src/main/java/com/efub/lakkulakku/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/notification/controller/NotificationController.java
@@ -25,7 +25,7 @@ public class NotificationController {
 	@ResponseStatus(HttpStatus.OK)
 	public SseEmitter subscribe(@AuthUsers Users user,
 								@RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
-		return notificationService.subscribe(user.getId(), lastEventId);
+		return notificationService.subscribe(user.getUserId(), lastEventId);
 	}
 
 	@GetMapping("/")

--- a/src/main/java/com/efub/lakkulakku/domain/notification/dto/NotificationMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/notification/dto/NotificationMapper.java
@@ -14,7 +14,7 @@ public class NotificationMapper {
 			return null;
 
 		return NotificationResDto.builder()
-				.id(entity.getId())
+				.id(entity.getNotificationId())
 				.message(entity.getMessage())
 				.build();
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/notification/entity/Notification.java
+++ b/src/main/java/com/efub/lakkulakku/domain/notification/entity/Notification.java
@@ -23,7 +23,7 @@ public class Notification extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID notificationId;
 
 	@ManyToOne
 	@JoinColumn(name = "users_id") //알람을 받는 유저

--- a/src/main/java/com/efub/lakkulakku/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/notification/service/NotificationService.java
@@ -51,7 +51,7 @@ public class NotificationService {
 	public void send(Users receiver, String notificationType, String message) {
 		Notification notification = notificationRepository.save(createNotification(receiver, notificationType, message));
 
-		String receiverId = String.valueOf(receiver.getId());
+		String receiverId = String.valueOf(receiver.getUserId());
 		String eventId = receiverId + "_" + System.currentTimeMillis();
 		Map<String, SseEmitter> emitters = emitterRepository.findAllStartWithById(receiverId);
 		emitters.forEach(
@@ -99,7 +99,7 @@ public class NotificationService {
 	@Transactional
 	public void deleteAllNotification(Users users)
 	{
-		List<Notification> notificationList = notificationRepository.findByUsersId(users.getId());
+		List<Notification> notificationList = notificationRepository.findByUsersId(users.getUserId());
 		notificationRepository.deleteAll(notificationList);
 	}
 

--- a/src/main/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateController.java
@@ -1,9 +1,13 @@
 package com.efub.lakkulakku.domain.profile.controller;
 
 import com.efub.lakkulakku.domain.profile.service.ProfileService;
+import com.efub.lakkulakku.domain.users.dto.LoginResDto;
 import com.efub.lakkulakku.domain.users.dto.ProfileUpdateResDto;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,10 +19,12 @@ public class ProfileUpdateController {
 	private final ProfileService profileService;
 
 	@PutMapping
-	public ProfileUpdateResDto updateProfile(@RequestParam(value = "nickname") String nickname,
-											 @RequestParam(value = "image", required = false) MultipartFile image,
-											 @RequestParam(value = "bio") String bio) throws Exception {
-		return profileService.updateUserProfile(nickname, image, bio);
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<ProfileUpdateResDto> updateProfile(@RequestParam(value = "nickname") String nickname,
+															 @RequestParam(value = "image", required = false) MultipartFile image,
+															 @RequestParam(value = "bio") String bio) throws Exception {
+
+		return new ResponseEntity<ProfileUpdateResDto>(profileService.updateUserProfile(nickname, image, bio), HttpStatus.OK);
 
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateController.java
@@ -4,6 +4,8 @@ import com.efub.lakkulakku.domain.profile.service.ProfileService;
 import com.efub.lakkulakku.domain.users.dto.ProfileUpdateResDto;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,11 +16,10 @@ public class ProfileUpdateController {
 
 	private final ProfileService profileService;
 
-	@PutMapping
-	public ProfileUpdateResDto updateProfile(@RequestParam(value = "nickname") String nickname,
-											 @RequestParam(value = "image", required = false) MultipartFile image,
-											 @RequestParam(value = "bio") String bio) throws Exception {
-		return profileService.updateUserProfile(nickname, image, bio);
-
+	@PostMapping
+	public ResponseEntity<ProfileUpdateResDto> updateProfile(@RequestParam(value = "nickname") String nickname,
+															@RequestParam(value = "image", required = false) MultipartFile image,
+															@RequestParam(value = "bio") String bio) throws Exception {
+		return ResponseEntity.status(HttpStatus.CREATED).body(profileService.updateUserProfile(nickname, image, bio));
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/profile/entity/Profile.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/entity/Profile.java
@@ -24,7 +24,7 @@ public class Profile extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID profileId;
 
 
 	@OneToOne(cascade = CascadeType.REMOVE)

--- a/src/main/java/com/efub/lakkulakku/domain/profile/entity/Profile.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/entity/Profile.java
@@ -50,4 +50,5 @@ public class Profile extends BaseTimeEntity {
 	public void updateFile(File file) {
 		this.file = file;
 	}
+
 }

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerMapper.java
@@ -18,7 +18,7 @@ public class StickerMapper {
 			return null;
 
 		return StickerResDto.builder()
-				.id(entity.getId())
+				.id(entity.getStickerId())
 				.width(entity.getWidth())
 				.height(entity.getHeight())
 				.x(entity.getX())

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/entity/Sticker.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/entity/Sticker.java
@@ -20,7 +20,7 @@ public class Sticker extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID stickerId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "diary_id")

--- a/src/main/java/com/efub/lakkulakku/domain/template/dto/TemplateMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/template/dto/TemplateMapper.java
@@ -17,7 +17,7 @@ public class TemplateMapper {
 			return null;
 
 		return com.efub.lakkulakku.domain.template.dto.TemplateResDto.builder()
-				.id(entity.getId())
+				.id(entity.getTemplateId())
 				.url(entity.getUrl())
 				.category(entity.getCategory())
 				.build();

--- a/src/main/java/com/efub/lakkulakku/domain/template/entity/Template.java
+++ b/src/main/java/com/efub/lakkulakku/domain/template/entity/Template.java
@@ -21,7 +21,7 @@ public class Template extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID templateId;
 
 	@OneToOne(mappedBy = "template", fetch = FetchType.LAZY)
 	@JoinColumn(name = "diary_id")

--- a/src/main/java/com/efub/lakkulakku/domain/templateResource/dto/TemplateResourceMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/templateResource/dto/TemplateResourceMapper.java
@@ -11,7 +11,7 @@ public class TemplateResourceMapper {
 			return null;
 
 		return TemplateResourceDto.builder()
-				.id(entity.getId())
+				.id(entity.getTemplateResourceId())
 				.url(entity.getUrl())
 				.category(entity.getCategory())
 				.build();

--- a/src/main/java/com/efub/lakkulakku/domain/templateResource/entity/TemplateResource.java
+++ b/src/main/java/com/efub/lakkulakku/domain/templateResource/entity/TemplateResource.java
@@ -14,7 +14,7 @@ public class TemplateResource {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private Long templateResourceId;
 
 	@Column(length = 2084)
 	@NotNull

--- a/src/main/java/com/efub/lakkulakku/domain/text/dto/TextMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/dto/TextMapper.java
@@ -18,7 +18,7 @@ public class TextMapper {
 			return null;
 
 		return TextResDto.builder()
-				.id(entity.getId())
+				.id(entity.getTextId())
 				.style(entity.getStyle())
 				.weight(entity.getWeight())
 				.size(entity.getSize())

--- a/src/main/java/com/efub/lakkulakku/domain/text/entity/Text.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/entity/Text.java
@@ -20,7 +20,7 @@ public class Text extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID textId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "diary_id")

--- a/src/main/java/com/efub/lakkulakku/domain/users/controller/LoginController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/controller/LoginController.java
@@ -36,7 +36,7 @@ public class LoginController {
 	@PostMapping("/signup")
 	public ResponseEntity<String> signup(@Valid @RequestBody SignupReqDto reqDto) {
 		usersService.signup(reqDto);
-		return ResponseEntity.ok(SIGNUP_SUCCESS);
+		return ResponseEntity.status(HttpStatus.CREATED).body(SIGNUP_SUCCESS);
 	}
 
 	@PostMapping("/signup/email")

--- a/src/main/java/com/efub/lakkulakku/domain/users/controller/LoginController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/controller/LoginController.java
@@ -90,7 +90,7 @@ public class LoginController {
 		LoginInfoDto loginInfoDto = usersService.login(loginDto.getEmail(), loginDto.getPassword());
 		HttpHeaders responseHeaders = new HttpHeaders();
 		responseHeaders.set("Set-Cookie",usersService.generateCookie("refreshToken", loginInfoDto.getRefreshToken()).toString());
-		return new ResponseEntity<LoginResDto>(loginInfoDto.toLoginResDto(), responseHeaders, HttpStatus.CREATED);
+		return new ResponseEntity<LoginResDto>(loginInfoDto.toLoginResDto(), responseHeaders, HttpStatus.OK);
 	}
 
 
@@ -105,7 +105,7 @@ public class LoginController {
 		LoginInfoDto responseDto = usersService.reIssueAccessToken(reqDto.getEmail(), refreshToken);
 		HttpHeaders responseHeaders = new HttpHeaders();
 		responseHeaders.set("Set-Cookie",usersService.generateCookie("refreshToken", responseDto.getRefreshToken()).toString());
-		return new ResponseEntity<LoginResDto>(responseDto.toLoginResDto(), responseHeaders, HttpStatus.CREATED);
+		return new ResponseEntity<LoginResDto>(responseDto.toLoginResDto(), responseHeaders, HttpStatus.OK);
 	}
 
 	@GetMapping("/logout")

--- a/src/main/java/com/efub/lakkulakku/domain/users/dto/HomeMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/dto/HomeMapper.java
@@ -25,8 +25,8 @@ public class HomeMapper {
 
 		return HomeResDto.builder()
 				.user(new ProfileUpdateResDto(entity))
-				.diary(diaryRepository.findUsersDiaryByYearAndMonth(entity.getId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList()))
-				.alarm(notificationRepository.findByUsersIdLimit(entity.getId()).stream().map(NotificationMapper::toNotificationResDto).collect(Collectors.toList()))
+				.diary(diaryRepository.findUsersDiaryByYearAndMonth(entity.getUserId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList()))
+				.alarm(notificationRepository.findByUsersIdLimit(entity.getUserId()).stream().map(NotificationMapper::toNotificationResDto).collect(Collectors.toList()))
 				.build();
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
@@ -59,4 +59,7 @@ public class Users extends BaseTimeEntity {
 	public void setPassword(String password) {
 		this.password = password;
 	}
+
+	//TODO : profile 연관관계 편의 메소드
+
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 
-@Setter
+
 @Getter
 @NoArgsConstructor
 @Entity
@@ -58,6 +58,9 @@ public class Users extends BaseTimeEntity {
 
 	public void setPassword(String password) {
 		this.password = password;
+	}
+	public void setId(UUID uuid){
+		this.id = uuid;
 	}
 
 	//TODO : profile 연관관계 편의 메소드

--- a/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
@@ -25,7 +25,7 @@ public class Users extends BaseTimeEntity {
 	@GeneratedValue(generator = "uuid2")
 	@GenericGenerator(name = "uuid2", strategy = "uuid2")
 	@Column(length = 16)
-	private UUID id;
+	private UUID userId;
 
 
 	@Column(unique = true, length = 12)
@@ -59,11 +59,12 @@ public class Users extends BaseTimeEntity {
 	public void setPassword(String password) {
 		this.password = password;
 	}
-	public void setId(UUID uuid){
-		this.id = uuid;
-	}
 	public void setProfile(Profile profile){
 		this.profile = profile;
+	}
+
+	public void setUserIdForTest(UUID userId){
+		this.userId = userId;
 	}
 
 	//TODO : profile 연관관계 편의 메소드

--- a/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
@@ -62,6 +62,9 @@ public class Users extends BaseTimeEntity {
 	public void setId(UUID uuid){
 		this.id = uuid;
 	}
+	public void setProfile(Profile profile){
+		this.profile = profile;
+	}
 
 	//TODO : profile 연관관계 편의 메소드
 

--- a/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
@@ -49,7 +49,6 @@ public class UsersService {
 		Users user = usersRepository.save(reqDto.toEntity());
 		Profile profile = Profile.builder()
 				.file(null)
-				.users(user)
 				.bio("반갑습니다 :)")
 				.build();
 		profileRepository.save(profile);

--- a/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
@@ -172,15 +172,15 @@ public class UsersService {
 			int nowYear = localDate.getYear();
 			int nowMonth = localDate.getMonthValue();
 
-			return diaryRepository.findUsersDiaryByYearAndMonth(user.getId(), Integer.toString(nowYear), Integer.toString(nowMonth)).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
+			return diaryRepository.findUsersDiaryByYearAndMonth(user.getUserId(), Integer.toString(nowYear), Integer.toString(nowMonth)).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
 		} else {
-			return diaryRepository.findUsersDiaryByYearAndMonth(user.getId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
+			return diaryRepository.findUsersDiaryByYearAndMonth(user.getUserId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
 		}
 	}
 
 	@Transactional
 	public List<NotificationResDto> findAllNotifications(Users user) {
-		List<Notification> notificationList = notificationRepository.findByUsersId(user.getId());
+		List<Notification> notificationList = notificationRepository.findByUsersId(user.getUserId());
 		return notificationList.stream()
 				.map(NotificationMapper::toNotificationResDto)
 				.collect(Collectors.toList());

--- a/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
@@ -190,6 +190,10 @@ public class UsersService {
 		return usersRepository.findByNickname(nickname)
 				.orElseThrow(UserNotFoundException::new);
 	}
+	@Transactional(readOnly = true)
+	public Users findByUid(Long uid){
+		return usersRepository.findByUid(uid).orElseThrow(UserNotFoundException::new);
+	}
 
 
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
@@ -21,16 +21,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UsersService {
 
 	private final UsersRepository usersRepository;
@@ -43,7 +45,6 @@ public class UsersService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtProvider jwtProvider;
 
-	@Transactional
 	public Users signup(SignupReqDto reqDto) {
 		reqDto.setPassword(passwordEncoder.encode(reqDto.getPassword()));
 		Users user = usersRepository.save(reqDto.toEntity());
@@ -55,7 +56,6 @@ public class UsersService {
 		return user;
 	}
 
-	@Transactional
 	public Users findUsersByEmail(LoginReqDto loginReqDto) {
 		return usersRepository.findByEmail(loginReqDto.getEmail())
 				.orElseThrow(UserNotFoundException::new);
@@ -146,7 +146,6 @@ public class UsersService {
 		jwtProvider.logout(email, accessToken);
 	}
 
-	@Transactional
 	public void deleteUser(WithdrawReqDto withdrawReqDto) {
 		Users users = usersRepository.findByNickname(withdrawReqDto.getNickname())
 				.orElseThrow(UserNotFoundException::new);
@@ -186,4 +185,11 @@ public class UsersService {
 				.map(NotificationMapper::toNotificationResDto)
 				.collect(Collectors.toList());
 	}
+	@Transactional(readOnly = true)
+	public Users findByNickname(String nickname){
+		return usersRepository.findByNickname(nickname)
+				.orElseThrow(UserNotFoundException::new);
+	}
+
+
 }

--- a/src/main/java/com/efub/lakkulakku/global/config/jwt/JwtProvider.java
+++ b/src/main/java/com/efub/lakkulakku/global/config/jwt/JwtProvider.java
@@ -27,7 +27,7 @@ public class JwtProvider {
 
 	private final CustomUsersDetailsService customUsersDetailsService;
 	@Value("${spring.jwt.secret-key}")
-	private String SECRET_KEY;
+	private String SECRET_KEY; //static 필드는 공유되는 상태를 나타내며, 다중 스레드 환경에서 안전하지 않을 수 있습니다. 그래서 인스턴스 변수를 사용하도록 변경
 
 
 	private static final Long TOKEN_VALID_TIME = 1000L * 60 * 120; // 2h
@@ -44,12 +44,12 @@ public class JwtProvider {
 
 	public String createAccessToken(String userId, String roles) {
 		Long tokenInvalidTime = 1000L * 60 * 120; // 2h
-		return this.createToken(userId, roles, tokenInvalidTime);
+		return createToken(userId, roles, tokenInvalidTime);
 	}
 
 	public String createRefreshToken(String userId, String roles) {
 		Long tokenInvalidTime = 1000L * 60 * 60 * 24; // 1d
-		String refreshToken = this.createToken(userId, roles, tokenInvalidTime);
+		String refreshToken = createToken(userId, roles, tokenInvalidTime);
 		redisService.setValues(userId, refreshToken, Duration.ofMillis(tokenInvalidTime));
 		return refreshToken;
 	}

--- a/src/test/java/com/efub/lakkulakku/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/comment/controller/CommentControllerTest.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import static com.efub.lakkulakku.global.constant.ResponseConstant.COMMENT_ADD_SUCCESS;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
@@ -100,8 +101,8 @@ class CommentControllerTest {
 				.message(COMMENT_ADD_SUCCESS)
 				.build();
 
-		when(diaryService.existsByDate(date)).thenReturn(true);
-		when(commentService.addComment(any(), any(), any())).thenReturn(testCommentResDto);
+		given(diaryService.existsByDate(date)).willReturn(true);
+		given(commentService.addComment(any(), any(), any())).willReturn(testCommentResDto);
 
 		// Perform request
 		mvc.perform(
@@ -153,8 +154,7 @@ class CommentControllerTest {
 				.modifiedOn(comment.getModifiedOn())
 				.build();
 
-		when(commentService.update(any(), any(), any())).thenReturn(testCommentUpdateResDto);
-		//TODO : create시에는 any안해도 되지만 update시는 any를 함,, 왜?
+		given(commentService.update(any(), any(), any())).willReturn(testCommentUpdateResDto);
 
 		// Perform request
 		mvc.perform(

--- a/src/test/java/com/efub/lakkulakku/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/comment/controller/CommentControllerTest.java
@@ -4,49 +4,44 @@ import com.efub.lakkulakku.domain.comment.dto.CommentReqDto;
 import com.efub.lakkulakku.domain.comment.dto.CommentResDto;
 import com.efub.lakkulakku.domain.comment.dto.CommentUpdateResDto;
 import com.efub.lakkulakku.domain.comment.entity.Comment;
-import com.efub.lakkulakku.domain.comment.exception.ParentNotFoundException;
+
 import com.efub.lakkulakku.domain.comment.repository.CommentRepository;
 import com.efub.lakkulakku.domain.comment.service.CommentService;
 import com.efub.lakkulakku.domain.diary.entity.Diary;
-import com.efub.lakkulakku.domain.diary.exception.DiaryNotFoundException;
-import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
+
 import com.efub.lakkulakku.domain.diary.service.DiaryService;
 import com.efub.lakkulakku.domain.profile.entity.Profile;
-import com.efub.lakkulakku.domain.users.controller.LoginController;
+
 import com.efub.lakkulakku.domain.users.entity.Users;
-import com.efub.lakkulakku.domain.users.service.AuthUsers;
+
 import com.efub.lakkulakku.global.config.TestUsers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
+
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+
 
 import java.time.LocalDate;
 import java.util.UUID;
 
 import static com.efub.lakkulakku.global.constant.ResponseConstant.COMMENT_ADD_SUCCESS;
-import static org.junit.jupiter.api.Assertions.*;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -62,6 +57,7 @@ class CommentControllerTest {
 
 	@MockBean
 	private CommentRepository commentRepository;
+
 
 	@MockBean
 	private DiaryService diaryService;
@@ -82,7 +78,7 @@ class CommentControllerTest {
 		Comment comment = Comment.builder()
 				.content(testContent)
 				.diary(diary)
-				.id(commentId)
+				.commentId(commentId)
 				.users(testUser)
 				.isSecret(isSecret)
 				.build();
@@ -92,7 +88,7 @@ class CommentControllerTest {
 				.isSecret(isSecret)
 				.build();
 		CommentResDto testCommentResDto = CommentResDto.builder()
-				.id(comment.getId())
+				.id(comment.getCommentId())
 				.createdOn(comment.getCreatedOn())
 				.parentId(comment.getParentId())
 				.content(comment.getContent())
@@ -134,19 +130,19 @@ class CommentControllerTest {
 		Comment comment = Comment.builder()
 				.content(testContent)
 				.diary(diary)
-				.id(commentId)
+				.commentId(commentId)
 				.isSecret(isSecret)
 				.users(testUser)
 				.build();
 		CommentReqDto testCommentReqDto = CommentReqDto.builder()
-				.id(comment.getId())
+				.commentId(comment.getCommentId())
 				.content(updateContent)
 				.diaryId(diary.getDiaryId())
 				.isSecret(isSecret)
 				.build();
 		comment.update(updateContent);
 		CommentUpdateResDto testCommentUpdateResDto = CommentUpdateResDto.builder()
-				.id(comment.getId())
+				.id(comment.getCommentId())
 				.parentId(comment.getParentId())
 				.content(comment.getContent())
 				.isSecret(comment.getIsSecret())

--- a/src/test/java/com/efub/lakkulakku/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,210 @@
+package com.efub.lakkulakku.domain.comment.controller;
+
+import com.efub.lakkulakku.domain.comment.dto.CommentReqDto;
+import com.efub.lakkulakku.domain.comment.dto.CommentResDto;
+import com.efub.lakkulakku.domain.comment.dto.CommentUpdateResDto;
+import com.efub.lakkulakku.domain.comment.entity.Comment;
+import com.efub.lakkulakku.domain.comment.exception.ParentNotFoundException;
+import com.efub.lakkulakku.domain.comment.repository.CommentRepository;
+import com.efub.lakkulakku.domain.comment.service.CommentService;
+import com.efub.lakkulakku.domain.diary.entity.Diary;
+import com.efub.lakkulakku.domain.diary.exception.DiaryNotFoundException;
+import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
+import com.efub.lakkulakku.domain.diary.service.DiaryService;
+import com.efub.lakkulakku.domain.profile.entity.Profile;
+import com.efub.lakkulakku.domain.users.controller.LoginController;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.service.AuthUsers;
+import com.efub.lakkulakku.global.config.TestUsers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static com.efub.lakkulakku.global.constant.ResponseConstant.COMMENT_ADD_SUCCESS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({CommentController.class})//웹 계층 테스트를 위한 어노테이션
+@ExtendWith(MockitoExtension.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class CommentControllerTest {
+
+	@Autowired
+	private MockMvc mvc;
+	@MockBean
+	private CommentService commentService;
+
+	@MockBean
+	private CommentRepository commentRepository;
+
+	@MockBean
+	private DiaryService diaryService;
+
+
+	private static final LocalDate date = LocalDate.of(2022, 7, 7);
+	private static final String BASE_URL = "/api/v1/diaries/";
+
+	@Test
+	@TestUsers
+	@DisplayName("댓글_생성_성공")
+	public void createComment() throws Exception {
+		Users testUser = createUsers();
+		Diary diary = createDiary(testUser);
+		String testContent = "test댓글";
+		boolean isSecret = true;
+		UUID commentId = UUID.randomUUID();
+		Comment comment = Comment.builder()
+				.content(testContent)
+				.diary(diary)
+				.id(commentId)
+				.users(testUser)
+				.isSecret(isSecret)
+				.build();
+		CommentReqDto testCommentReqDto = CommentReqDto.builder()
+				.content(testContent)
+				.diaryId(diary.getDiaryId())
+				.isSecret(isSecret)
+				.build();
+		CommentResDto testCommentResDto = CommentResDto.builder()
+				.id(comment.getId())
+				.createdOn(comment.getCreatedOn())
+				.parentId(comment.getParentId())
+				.content(comment.getContent())
+				.nickname(comment.getUsers().getNickname())
+				.isSecret(comment.getIsSecret())
+				.message(COMMENT_ADD_SUCCESS)
+				.build();
+
+		when(diaryService.existsByDate(date)).thenReturn(true);
+		when(commentService.addComment(any(), any(), any())).thenReturn(testCommentResDto);
+
+		// Perform request
+		mvc.perform(
+						MockMvcRequestBuilders.post(BASE_URL + date + "/comments")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(new ObjectMapper().writeValueAsString(testCommentReqDto))
+								.with(csrf())
+				)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").value(testCommentResDto.getContent()));
+
+		// Verify behavior
+		verify(diaryService).existsByDate(date);
+
+
+	}
+
+	@Test
+	@TestUsers
+	@DisplayName("댓글_수정_성공")
+	public void updateComment() throws Exception {
+		Users testUser = createUsers();
+		Diary diary = createDiary(testUser);
+		String testContent = "test댓글";
+		String updateContent = "수정 후 댓글";
+		boolean isSecret = true;
+
+		UUID commentId = UUID.randomUUID();
+		Comment comment = Comment.builder()
+				.content(testContent)
+				.diary(diary)
+				.id(commentId)
+				.isSecret(isSecret)
+				.users(testUser)
+				.build();
+		CommentReqDto testCommentReqDto = CommentReqDto.builder()
+				.id(comment.getId())
+				.content(updateContent)
+				.diaryId(diary.getDiaryId())
+				.isSecret(isSecret)
+				.build();
+		comment.update(updateContent);
+		CommentUpdateResDto testCommentUpdateResDto = CommentUpdateResDto.builder()
+				.id(comment.getId())
+				.parentId(comment.getParentId())
+				.content(comment.getContent())
+				.isSecret(comment.getIsSecret())
+				.nickname(comment.getUsers().getNickname())
+				.modifiedOn(comment.getModifiedOn())
+				.build();
+
+		when(commentService.update(any(), any(), any())).thenReturn(testCommentUpdateResDto);
+		//TODO : create시에는 any안해도 되지만 update시는 any를 함,, 왜?
+
+		// Perform request
+		mvc.perform(
+						MockMvcRequestBuilders.put(BASE_URL + date + "/comments")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(new ObjectMapper().writeValueAsString(testCommentReqDto))
+								.with(csrf())
+				)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").value(testCommentUpdateResDto.getContent()));
+
+
+
+	}
+
+
+
+
+
+
+	private Diary createDiary(Users user){
+		UUID diaryId = UUID.randomUUID();
+		Diary diary = Diary.builder()
+				.user(user)
+				.date(date)
+				.build();
+		diary.setDaryId(diaryId);
+
+
+		return diary;
+	}
+	private Users createUsers(){
+		final String email = "test@gmail";
+		final String nickname = "테스트계정";
+		final String encodedPassword = "encodedPassoword";
+		final String bio = "안녕";
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.build();
+		Profile profile = Profile.builder()
+				.file(null)
+				.bio(bio)
+				.users(user)
+				.build();
+		user.setProfile(profile);
+		return user;
+	}
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/diary/entity/DiaryTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/diary/entity/DiaryTest.java
@@ -1,0 +1,120 @@
+//package com.efub.lakkulakku.domain.diary.entity;
+//
+//import com.efub.lakkulakku.domain.comment.entity.Comment;
+//import com.efub.lakkulakku.domain.image.entity.Image;
+//import com.efub.lakkulakku.domain.likes.entity.Likes;
+//import com.efub.lakkulakku.domain.sticker.entity.Sticker;
+//import com.efub.lakkulakku.domain.text.entity.Text;
+//import com.efub.lakkulakku.domain.users.entity.Users;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.springframework.test.context.junit.jupiter.SpringExtension;
+//
+//import java.time.LocalDate;
+//import java.util.ArrayList;
+//import java.util.List;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//@ExtendWith(SpringExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
+//class DiaryTest {
+//
+//	@Builder
+//	public Diary(Users user, LocalDate date, List<Comment> comments,
+//				 List<Image> images, List<Likes> likes, List<Text> texts, List<Sticker> stickers) {
+//		this.user = user;
+//		this.date = date;
+//		this.comments = comments;
+//		this.images = images;
+//		this.likes = likes;
+//		this.texts = texts;
+//		this.stickers = stickers;
+//
+//		Users user = new Users();
+//		user.setName("test user");
+//
+//		// Create a diary
+//		Diary diary = Diary.builder()
+//				.user(user)
+//				.date(LocalDate.now())
+//				.build();
+//
+//		// Create some comments for the diary
+//		Comment comment1 = new Comment();
+//		comment1.update("test comment 1");
+//		Comment comment2 = new Comment();
+//		comment2.update("test comment 2");
+//		List<Comment> commentList = new ArrayList<>();
+//		commentList.add(comment1);
+//		commentList.add(comment2);
+//		diary.getComments().addAll(commentList);
+//
+//		// Create a template for the diary
+//		Template template = new Template();
+//		template.setName("test template");
+//		diary.setTemplate(template);
+//
+//		// Create some images for the diary
+//		Image image1 = new Image();
+//		image1.setUrl("test url 1");
+//		Image image2 = new Image();
+//		image2.setUrl("test url 2");
+//		List<Image> imageList = new ArrayList<>();
+//		imageList.add(image1);
+//		imageList.add(image2);
+//		diary.getImages().addAll(imageList);
+//
+//		// Create some likes for the diary
+//		Likes like1 = new Likes();
+//		Likes like2 = new Likes();
+//		List<Likes> likesList = new ArrayList<>();
+//		likesList.add(like1);
+//		likesList.add(like2);
+//		diary.getLikes().addAll(likesList);
+//
+//		// Create some texts for the diary
+//		Text text1 = new Text();
+//		text1.setContent("test text 1");
+//		Text text2 = new Text();
+//		text2.setContent("test text 2");
+//		List<Text> textList = new ArrayList<>();
+//		textList.add(text1);
+//		textList.add(text2);
+//		diary.getTexts().addAll(textList);
+//
+//		// Create some stickers for the diary
+//		Sticker sticker1 = new Sticker();
+//		sticker1.setName("test sticker 1");
+//		Sticker sticker2 = new Sticker();
+//		sticker2.setName("test sticker 2");
+//		List<Sticker> stickerList = new ArrayList<>();
+//		stickerList.add(sticker1);
+//		stickerList.add(sticker2);
+//		diary.getStickers().addAll(stickerList);
+//
+//		// Set the diary's comment count and like count
+//		diary.setCntComment(commentList.size());
+//		diary.setCntLike(likesList.size());
+//
+//		// Save the diary to the database
+//
+//
+//
+//
+//
+//	}
+//
+//	@Test
+//	@DisplayName("다이어리 생성 테스트")
+//	void createDiary(){
+//		final String title = "title";
+//		final List<Comment> comments = null;
+//		final List<Image> images = null;
+//		final List<Likes> likes = null;
+//		final List<Text> texts = null;
+//		final List<Sticker> stickers = null;
+//	}
+//
+//
+//
+//}

--- a/src/test/java/com/efub/lakkulakku/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/diary/service/DiaryServiceTest.java
@@ -1,0 +1,77 @@
+package com.efub.lakkulakku.domain.diary.service;
+
+import com.efub.lakkulakku.domain.comment.dto.CommentMapper;
+import com.efub.lakkulakku.domain.comment.repository.CommentRepository;
+import com.efub.lakkulakku.domain.diary.dto.DiaryMapper;
+import com.efub.lakkulakku.domain.diary.dto.DiarySaveReqDto;
+import com.efub.lakkulakku.domain.diary.entity.Diary;
+import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
+import com.efub.lakkulakku.domain.likes.repository.LikesRepository;
+import com.efub.lakkulakku.domain.template.entity.Template;
+import com.efub.lakkulakku.domain.template.repository.TemplateRepository;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryServiceTest {
+	@InjectMocks
+	private DiaryService diaryService;
+
+	@Mock
+	private DiaryRepository diaryRepository;
+	@Mock
+	private TemplateRepository templateRepository;
+	@Mock
+	private CommentRepository commentRepository;
+	@Mock
+	private LikesRepository likesRepository;
+	@Mock
+	private DiaryMapper diaryMapper;
+	@Mock
+	private CommentMapper commentMapper;
+
+	@Test
+	public void createDiaryTest() {
+		LocalDate diaryDate = LocalDate.now();
+		Users user = mock(Users.class);
+		when(diaryRepository.existsByDateAndUserId(diaryDate, user.getId())).thenReturn(false);
+
+		diaryService.createDiary(user, diaryDate);
+
+		verify(diaryRepository, times(1)).existsByDateAndUserId(diaryDate, user.getId());
+		verify(diaryRepository, times(1)).save(any(Diary.class));
+		verify(templateRepository, times(1)).save(any(Template.class));
+	}
+
+	@Test
+	public void saveDiaryTest() throws IOException {
+		LocalDate date = LocalDate.now();
+		Users user = mock(Users.class);
+		DiarySaveReqDto dto = mock(DiarySaveReqDto.class);
+		Diary diary = mock(Diary.class);
+		Diary savedDiary = mock(Diary.class);
+
+		when(diaryRepository.findByDateAndUserId(date, user.getId())).thenReturn(java.util.Optional.of(diary));
+		when(diaryMapper.saveDiary(diary, dto)).thenReturn(savedDiary);
+
+		diaryService.saveDiary(date, user, dto);
+
+		verify(diaryRepository, times(1)).findByDateAndUserId(date, user.getId());
+		verify(diaryMapper, times(1)).saveDiary(diary, dto);
+		verify(diaryRepository, times(1)).save(savedDiary);
+	}
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/diary/service/DiaryServiceTest.java
@@ -47,11 +47,11 @@ class DiaryServiceTest {
 	public void createDiaryTest() {
 		LocalDate diaryDate = LocalDate.now();
 		Users user = mock(Users.class);
-		when(diaryRepository.existsByDateAndUserId(diaryDate, user.getId())).thenReturn(false);
+		when(diaryRepository.existsByDateAndUser(diaryDate, user)).thenReturn(false);
 
 		diaryService.createDiary(user, diaryDate);
 
-		verify(diaryRepository, times(1)).existsByDateAndUserId(diaryDate, user.getId());
+		verify(diaryRepository, times(1)).existsByDateAndUser(diaryDate, user);
 		verify(diaryRepository, times(1)).save(any(Diary.class));
 		verify(templateRepository, times(1)).save(any(Template.class));
 	}
@@ -64,12 +64,12 @@ class DiaryServiceTest {
 		Diary diary = mock(Diary.class);
 		Diary savedDiary = mock(Diary.class);
 
-		when(diaryRepository.findByDateAndUserId(date, user.getId())).thenReturn(java.util.Optional.of(diary));
+		when(diaryRepository.findByDateAndUser(date, user)).thenReturn(java.util.Optional.of(diary));
 		when(diaryMapper.saveDiary(diary, dto)).thenReturn(savedDiary);
 
 		diaryService.saveDiary(date, user, dto);
 
-		verify(diaryRepository, times(1)).findByDateAndUserId(date, user.getId());
+		verify(diaryRepository, times(1)).findByDateAndUser(date, user);
 		verify(diaryMapper, times(1)).saveDiary(diary, dto);
 		verify(diaryRepository, times(1)).save(savedDiary);
 	}

--- a/src/test/java/com/efub/lakkulakku/domain/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/friend/controller/FriendControllerTest.java
@@ -1,0 +1,174 @@
+package com.efub.lakkulakku.domain.friend.controller;
+
+import com.efub.lakkulakku.domain.comment.controller.CommentController;
+import com.efub.lakkulakku.domain.comment.repository.CommentRepository;
+import com.efub.lakkulakku.domain.comment.service.CommentService;
+import com.efub.lakkulakku.domain.diary.service.DiaryService;
+import com.efub.lakkulakku.domain.friend.dto.FriendReqDto;
+import com.efub.lakkulakku.domain.friend.entity.Friend;
+import com.efub.lakkulakku.domain.friend.exception.DuplicateFriendException;
+import com.efub.lakkulakku.domain.friend.exception.SelfFriendException;
+import com.efub.lakkulakku.domain.friend.service.FriendService;
+import com.efub.lakkulakku.domain.profile.entity.Profile;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.domain.users.service.AuthUsers;
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import com.efub.lakkulakku.global.config.TestUsers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.UUID;
+
+import static com.efub.lakkulakku.global.constant.ResponseConstant.DELETE_FRIEND_SUCCESS;
+import static com.efub.lakkulakku.global.constant.ResponseConstant.FRIEND_SUCCESS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@WebMvcTest({FriendController.class})//웹 계층 테스트를 위한 어노테이션
+@ExtendWith(MockitoExtension.class)
+@MockBean(JpaMetamodelMappingContext.class) //JPA auditing 기능을 사용하기 때문에 JPA 메타 모델을 처리하기 위해 사용
+class FriendControllerTest {
+	@Autowired
+	private MockMvc mvc;
+	@MockBean
+	private FriendService friendService;
+	@MockBean
+	private UsersService usersService;
+
+	@MockBean
+	private UsersRepository usersRepository;
+
+	private static final String BASE_URL = "/api/v1/friends";
+
+
+
+	@Test
+	@TestUsers
+	@DisplayName("친구_생성_자기자신을 친구로 등록")
+	public void addFriend_self() throws Exception {
+		Long uid = 1L;
+		FriendReqDto reqDto = new FriendReqDto(uid);
+
+		assertThrows(SelfFriendException.class, () -> {
+			mvc.perform(MockMvcRequestBuilders
+					.post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(new ObjectMapper().writeValueAsString(reqDto))
+					.with(csrf()));
+		});
+	}
+
+	@Test
+	@TestUsers
+	@DisplayName("친구_생성_중복 친구")
+	public void addFriend_duplicate() throws Exception {
+		Users user = createUsers();
+		Users targetUser = createTarget();
+
+		FriendReqDto reqDto = new FriendReqDto(targetUser.getUid());
+
+		given(usersService.findByUid(any())).willReturn(targetUser);
+		given(friendService.isFriend(any(), any())).willReturn(new Friend(user, targetUser).getFriendId());;
+
+		assertThrows(DuplicateFriendException.class, () -> {
+			mvc.perform(MockMvcRequestBuilders
+					.post(BASE_URL)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(new ObjectMapper().writeValueAsString(reqDto))
+					.with(csrf()));
+		});
+	}
+
+	@Test
+	@TestUsers
+	@DisplayName("친구_생성_성공")
+	public void addFriend_success() throws Exception {
+		Users user = createUsers();
+		Users target = createTarget();
+		FriendReqDto reqDto = new FriendReqDto(target.getUid());
+
+		given(usersService.findByUid(any())).willReturn(user);
+		given(friendService.isFriend(any(), any())).willReturn(null);
+
+		mvc.perform(MockMvcRequestBuilders
+						.post(BASE_URL)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(new ObjectMapper().writeValueAsString(reqDto))
+						.with(csrf()))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.content().string(FRIEND_SUCCESS));
+	}
+
+	@Test
+	@TestUsers
+	@DisplayName("친구_삭제_성공")
+	public void deleteFriend() throws Exception{
+
+		Users targetUser = createTarget();
+		FriendReqDto reqDto = new FriendReqDto(targetUser.getUid());
+		Users user = createUsers();
+
+		doNothing().when(friendService).deleteFriend(any(), any());
+
+		mvc.perform(MockMvcRequestBuilders
+						.delete(BASE_URL)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(new ObjectMapper().writeValueAsString(reqDto))
+						.with(csrf()))
+				.andExpect(MockMvcResultMatchers.status().isOk())
+				.andExpect(MockMvcResultMatchers.content().string(DELETE_FRIEND_SUCCESS));
+	}
+
+	private Users createUsers(){
+		final String email = "test@gmail";
+		final String nickname = "테스트계정";
+		final String encodedPassword = "encodedPassoword";
+		final String bio = "안녕";
+		final Long uid = 1L;
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.uid(uid)
+				.build();
+		return user;
+	}
+	private Users createTarget(){
+		final String email = "testFriend@gmail";
+		final String nickname = "친구계정";
+		final String encodedPassword = "encodedFriendPassoword";
+		final String bio = "안녕";
+		final Long uid = 2L;
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.uid(uid)
+				.build();
+		return user;
+	}
+
+
+
+	}
+
+
+

--- a/src/test/java/com/efub/lakkulakku/domain/likes/controller/LikesControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/likes/controller/LikesControllerTest.java
@@ -71,7 +71,7 @@ class LikesControllerTest {
 				.isLike(isLike)
 				.build();
 		LikeClickResDto likeClickResDto = LikeClickResDto.builder()
-				.id(likes.getId())
+				.id(likes.getLikeId())
 				.diaryId(diary.getDiaryId())
 				.message(LIKES_ADD_SUCCESS)
 				.isLike(isLike)

--- a/src/test/java/com/efub/lakkulakku/domain/likes/controller/LikesControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/likes/controller/LikesControllerTest.java
@@ -1,0 +1,130 @@
+package com.efub.lakkulakku.domain.likes.controller;
+
+import com.efub.lakkulakku.domain.diary.entity.Diary;
+import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
+import com.efub.lakkulakku.domain.likes.dto.LikeClickResDto;
+import com.efub.lakkulakku.domain.likes.dto.LikeReqDto;
+import com.efub.lakkulakku.domain.likes.entity.Likes;
+import com.efub.lakkulakku.domain.likes.service.LikesService;
+import com.efub.lakkulakku.domain.profile.controller.ProfileUpdateController;
+import com.efub.lakkulakku.domain.profile.entity.Profile;
+import com.efub.lakkulakku.domain.profile.service.ProfileService;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.global.config.TestUsers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.efub.lakkulakku.global.constant.ResponseConstant.LIKES_ADD_SUCCESS;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest({LikesController.class})//웹 계층 테스트를 위한 어노테이션
+@ExtendWith(MockitoExtension.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class LikesControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private LikesService likesService;
+
+	@MockBean
+	private DiaryRepository diaryRepository;
+
+	@Test
+	@TestUsers
+	@DisplayName("좋아요_생성_성공")
+	public void createdLikes() throws Exception {
+		final boolean isLike = true;
+		Users user = createUsers();
+		Diary diary = createDiary(user);
+		LocalDate date = LocalDate.of(2023, 5, 9);
+		LikeReqDto likeReqDto = new LikeReqDto(diary.getId());
+		Likes likes = Likes.builder()
+				.diary(diary)
+				.users(user)
+				.isLike(isLike)
+				.build();
+		LikeClickResDto likeClickResDto = LikeClickResDto.builder()
+				.id(likes.getId())
+				.diaryId(diary.getId())
+				.message(LIKES_ADD_SUCCESS)
+				.isLike(isLike)
+				.build();
+
+		// Mock the dependencies
+		given(likesService.clickLike(any(), any(), any())).willReturn(likeClickResDto);
+
+		// Perform the request and check the results
+		mockMvc.perform(
+						MockMvcRequestBuilders.post("/api/v1/diaries/{date}/like", date)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(new ObjectMapper().writeValueAsString(likeReqDto))
+								.with(csrf())
+				)
+
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andExpect(jsonPath("$.isLike").value(likeClickResDto.getIsLike()));
+
+	}
+
+
+	private Users createUsers(){
+		final String email = "test@gmail";
+		final String nickname = "테스트계정";
+		final String encodedPassword = "encodedPassoword";
+		final String bio = "안녕";
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.build();
+		Profile profile = Profile.builder()
+				.file(null)
+				.bio(bio)
+				.users(user)
+				.build();
+		user.setProfile(profile);
+		return user;
+	}
+
+	private Diary createDiary(Users user){
+		LocalDate date = LocalDate.of(2023, 5, 9);
+
+		Diary diary = Diary.builder()
+				.user(user)
+				.date(date)
+				.build();
+
+
+		return diary;
+	}
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/likes/controller/LikesControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/likes/controller/LikesControllerTest.java
@@ -64,7 +64,7 @@ class LikesControllerTest {
 		Users user = createUsers();
 		Diary diary = createDiary(user);
 		LocalDate date = LocalDate.of(2023, 5, 9);
-		LikeReqDto likeReqDto = new LikeReqDto(diary.getId());
+		LikeReqDto likeReqDto = new LikeReqDto(diary.getDiaryId());
 		Likes likes = Likes.builder()
 				.diary(diary)
 				.users(user)
@@ -72,7 +72,7 @@ class LikesControllerTest {
 				.build();
 		LikeClickResDto likeClickResDto = LikeClickResDto.builder()
 				.id(likes.getId())
-				.diaryId(diary.getId())
+				.diaryId(diary.getDiaryId())
 				.message(LIKES_ADD_SUCCESS)
 				.isLike(isLike)
 				.build();

--- a/src/test/java/com/efub/lakkulakku/domain/likes/service/LikesServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/likes/service/LikesServiceTest.java
@@ -1,0 +1,77 @@
+package com.efub.lakkulakku.domain.likes.service;
+
+import com.efub.lakkulakku.domain.diary.entity.Diary;
+import com.efub.lakkulakku.domain.diary.service.DiaryService;
+import com.efub.lakkulakku.domain.likes.dto.LikeClickResDto;
+import com.efub.lakkulakku.domain.likes.dto.LikeMapper;
+import com.efub.lakkulakku.domain.likes.dto.LikeReqDto;
+import com.efub.lakkulakku.domain.likes.entity.Likes;
+import com.efub.lakkulakku.domain.likes.repository.LikesRepository;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class LikesServiceTest {
+
+	@InjectMocks
+	private LikesService likesService;
+
+	@Mock
+	private LikesRepository likesRepository;
+	@Mock
+	private LikeMapper likeMapper;
+	@Mock
+	private DiaryService diaryService;
+
+	@Test
+	@DisplayName("종아요_생성_성공")
+	public void clickLikeTest() {
+		LocalDate date = LocalDate.now();
+		Users user = mock(Users.class);
+		LikeReqDto likeReqDto = mock(LikeReqDto.class);
+		Diary diary = createDiary(user);
+
+		Likes likes = Likes.builder()
+				.isLike(false)
+				.diary(diary)
+				.build();
+		diary.setCntLike(1);
+
+		when(likeReqDto.getDiaryId()).thenReturn(diary.getId());
+		when(diaryService.findById(likeReqDto.getDiaryId())).thenReturn(diary);
+		when(likesRepository.existsByDiaryAndUsers(diary, user)).thenReturn(false);
+		when(likeMapper.toEntityFromReqDto(user, diary, likeReqDto)).thenReturn(likes);
+
+		LikeClickResDto result = likesService.clickLike(user, date, likeReqDto);
+
+		verify(likesRepository, times(1)).existsByDiaryAndUsers(diary, user);
+		verify(likesRepository, times(1)).save(likes);
+		verify(diaryService, times(1)).save(diary);
+	}
+
+	private Diary createDiary(Users user){
+		LocalDate date = LocalDate.of(2023, 5, 9);
+
+		Diary diary = Diary.builder()
+				.user(user)
+				.date(date)
+				.build();
+
+
+		return diary;
+	}
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/likes/service/LikesServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/likes/service/LikesServiceTest.java
@@ -49,7 +49,7 @@ class LikesServiceTest {
 				.build();
 		diary.setCntLike(1);
 
-		when(likeReqDto.getDiaryId()).thenReturn(diary.getId());
+		when(likeReqDto.getDiaryId()).thenReturn(diary.getDiaryId());
 		when(diaryService.findById(likeReqDto.getDiaryId())).thenReturn(diary);
 		when(likesRepository.existsByDiaryAndUsers(diary, user)).thenReturn(false);
 		when(likeMapper.toEntityFromReqDto(user, diary, likeReqDto)).thenReturn(likes);

--- a/src/test/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateControllerTest.java
@@ -1,0 +1,126 @@
+package com.efub.lakkulakku.domain.profile.controller;
+
+import com.efub.lakkulakku.domain.profile.entity.Profile;
+import com.efub.lakkulakku.domain.profile.service.ProfileService;
+import com.efub.lakkulakku.domain.users.controller.LoginController;
+import com.efub.lakkulakku.domain.users.dto.ProfileUpdateResDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.global.config.TestUsers;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.web.servlet.function.RequestPredicates.contentType;
+
+
+@WebMvcTest({ProfileUpdateController.class})//웹 계층 테스트를 위한 어노테이션
+@ExtendWith(MockitoExtension.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class ProfileUpdateControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private ProfileService profileService;
+
+	@Test
+	@TestUsers
+	@DisplayName("프로필_업데이트_성공")
+	public void testUpdateProfile() throws Exception {
+
+		// given
+		Users user = createUsers();
+		String nickname = "changeNickname";
+		String updateBio = "변경자기소개";
+
+		MockMultipartFile image = new MockMultipartFile(
+				"image",
+				"image.jpg",
+				MediaType.IMAGE_JPEG_VALUE,
+				"image data".getBytes()
+		);
+
+		ProfileUpdateResDto expectedResponse = new ProfileUpdateResDto(user);
+
+		given(profileService.updateUserProfile(any(), any(), any())).willReturn(expectedResponse);
+
+		// when
+		mockMvc.perform(
+						put("/api/v1/profile")
+								.contentType(MediaType.MULTIPART_FORM_DATA)
+								.param("nickname", nickname)
+								.param("bio", updateBio)
+								.param("image", image.getOriginalFilename(), String.valueOf(image.getBytes()))
+								.with(csrf())
+				)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(expectedResponse.getId()))
+				.andExpect(jsonPath("$.profileImage").value(expectedResponse.getProfileImage()))
+				.andExpect(jsonPath("$.nickname").value(expectedResponse.getNickname()))
+				.andExpect(jsonPath("$.bio").value(expectedResponse.getBio()))
+				.andDo(print());
+
+
+		//TODO: json empty 문제
+
+				//.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				//.andExpect(content().json(new ObjectMapper().writeValueAsString(expectedResponse)));
+				//.andExpect(jsonPath("$.id"), is(expectedResponse.getId()))
+				//.andExpect(jsonPath("$.profileImage").value(expectedResponse.getProfileImage()))
+				//.andExpect(jsonPath("$.nickname").value(expectedResponse.getNickname()))
+				//.andExpect(jsonPath("$.bio").value(expectedResponse.getBio()));
+
+
+	}
+
+	private Users createUsers(){
+		final String email = "test@gmail";
+		final String nickname = "테스트계정";
+		final String encodedPassword = "encodedPassoword";
+		final String bio = "안녕";
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.build();
+		Profile profile = Profile.builder()
+				.file(null)
+				.bio(bio)
+				.users(user)
+				.build();
+		user.setProfile(profile);
+		return user;
+	}
+
+
+
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/profile/entity/ProfileTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/profile/entity/ProfileTest.java
@@ -1,0 +1,70 @@
+package com.efub.lakkulakku.domain.profile.entity;
+
+import com.efub.lakkulakku.domain.users.entity.Users;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
+class ProfileTest {
+
+	@Test
+	@DisplayName("프로필 생성 테스트")
+	void createProfile() {
+		Users user = createUsers();
+		String bio = "안녕하세요";
+
+		Profile profile = Profile.builder()
+				.bio(bio)
+				.users(user)
+				.file(null)
+				.build();
+
+		assertThat(profile.getBio()).isEqualTo(bio);
+		assertThat(profile.getFile()).isEqualTo(null);//TODO:지금은 null값이지만 추후에 변경 예정
+		assertThat(profile.getUsers()).isEqualTo(user);
+
+	}
+
+	@Test
+	@DisplayName("프로필 변경 테스트")
+	void updateProfile() {
+		Users user = createUsers();
+		String bio = "안녕하세요";
+		String updateBio = "변경했습니다.";
+
+		Profile profile = Profile.builder()
+				.bio(bio)
+				.users(user)
+				.file(null)
+				.build();
+		profile.updateBio(updateBio);
+
+		assertThat(profile.getBio()).isEqualTo(updateBio);
+
+	}
+
+
+
+
+	private Users createUsers(){
+		final String email = "test@gmail";
+		final String nickname = "테스트계정";
+		final String encodedPassword = "encodedPassoword";
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.build();
+		return user;
+	}
+
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/user/controller/LoginControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/user/controller/LoginControllerTest.java
@@ -52,10 +52,13 @@ public class LoginControllerTest {
 
 
 			// given
+			String email = "signuptest@gmail.com";
+			String nickname = "회원가입테스트";
+			String password = "1234";
 			SignupReqDto signupReqDto = SignupReqDto.builder()
-					.email("signuptest@gmail.com")
-					.nickname("회원가입테스트")
-					.password(passwordEncoder.encode("1234"))
+					.email(email)
+					.nickname(nickname)
+					.password(passwordEncoder.encode(password))
 					.build();
 
 			HttpEntity<SignupReqDto> requestEntity = new HttpEntity<>(signupReqDto);

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/LoginControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/LoginControllerTest.java
@@ -1,31 +1,24 @@
 package com.efub.lakkulakku.domain.users.controller;
 
+import com.efub.lakkulakku.domain.users.dto.LoginInfoDto;
+import com.efub.lakkulakku.domain.users.dto.LoginReqDto;
+import com.efub.lakkulakku.domain.users.dto.LoginResDto;
 import com.efub.lakkulakku.domain.users.dto.SignupReqDto;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import com.efub.lakkulakku.domain.users.service.UsersService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-@ExtendWith(MockitoExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
-class LoginControllerTest {
+public class LoginControllerTest {
 
 	@InjectMocks
 	LoginController loginController;
@@ -34,39 +27,37 @@ class LoginControllerTest {
 	UsersService usersService;
 
 	@Test
-	@DisplayName("회원가입_서비스_성공")
-	void signupController()  {
+	@DisplayName("로그인_서비스_성공")
+	void loginUsersService(){
 		String email = "test1234@gmail.com";
 		String password = "test1234!!";
 		String nickname = "test";
-		String bio = "반갑습니다 :)";
-		final SignupReqDto reqDto = SignupReqDto.builder()
+
+		String accessToken = "accessToken";
+		String refreshToken = "refreshToken";
+		final LoginReqDto reqDto = LoginReqDto.builder()
 				.email(email)
 				.password(password)
-				.nickname(nickname)
 				.build();
 
-		Users users = reqDto.toEntity();
+		final LoginInfoDto loginInfoDto = LoginInfoDto.builder()
+				.refreshToken(refreshToken)
+				.accessToken(accessToken)
+				.nickname(nickname)
+				.build();
+		LoginResDto loginResDto = loginInfoDto.toLoginResDto();
+		given(usersService.login(email, password)).willReturn(loginInfoDto);
 
-		given(usersService.signup(any(SignupReqDto.class))).willReturn(users);
 
 		// when
-		ResponseEntity<String> response = loginController.signup(reqDto);
+		ResponseEntity<LoginResDto> response = loginController.login(reqDto);
 
 		// then
-		verify(usersService).signup(reqDto);//usersService.signup() 메소드가 호출되었는지 확인
+		verify(usersService).login(email, password);//usersService.signup() 메소드가 호출되었는지 확인
 		assertEquals(HttpStatus.OK, response.getStatusCode());
-		assertEquals("성공적으로 가입되었습니다.", response.getBody());
+		//assertEquals("성공적으로 가입되었습니다.", response.getBody());
 
 	}
 
-	@Test
-	@DisplayName("로그인_서비스_성공")
-	void loginUsersService(){
-
 	}
 
-
-
-
-}

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/LoginControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/LoginControllerTest.java
@@ -1,0 +1,72 @@
+package com.efub.lakkulakku.domain.users.controller;
+
+import com.efub.lakkulakku.domain.users.dto.SignupReqDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@ExtendWith(MockitoExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
+class LoginControllerTest {
+
+	@InjectMocks
+	LoginController loginController;
+
+	@Mock
+	UsersService usersService;
+
+	@Test
+	@DisplayName("회원가입_서비스_성공")
+	void signupController()  {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test";
+		String bio = "반갑습니다 :)";
+		final SignupReqDto reqDto = SignupReqDto.builder()
+				.email(email)
+				.password(password)
+				.nickname(nickname)
+				.build();
+
+		Users users = reqDto.toEntity();
+
+		given(usersService.signup(any(SignupReqDto.class))).willReturn(users);
+
+		// when
+		ResponseEntity<String> response = loginController.signup(reqDto);
+
+		// then
+		verify(usersService).signup(reqDto);//usersService.signup() 메소드가 호출되었는지 확인
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("성공적으로 가입되었습니다.", response.getBody());
+
+	}
+
+	@Test
+	@DisplayName("로그인_서비스_성공")
+	void loginUsersService(){
+
+	}
+
+
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/SignUpControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/SignUpControllerTest.java
@@ -51,7 +51,7 @@ class SignUpControllerTest {//단위 테스트
 
 		// then
 		verify(usersService).signup(reqDto);//usersService.signup() 메소드가 호출되었는지 확인
-		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals(HttpStatus.CREATED, response.getStatusCode());
 		assertEquals("성공적으로 가입되었습니다.", response.getBody());
 
 	}

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/SignUpControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/SignUpControllerTest.java
@@ -1,0 +1,64 @@
+package com.efub.lakkulakku.domain.users.controller;
+
+import com.efub.lakkulakku.domain.users.dto.SignupReqDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@ExtendWith(MockitoExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
+class SignUpControllerTest {//단위 테스트
+
+	@InjectMocks
+	LoginController loginController;
+
+	@Mock
+	UsersService usersService;
+
+	@Test
+	@DisplayName("회원가입_서비스_성공")
+	void signupController()  {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test";
+		String bio = "반갑습니다 :)";
+		final SignupReqDto reqDto = SignupReqDto.builder()
+				.email(email)
+				.password(password)
+				.nickname(nickname)
+				.build();
+
+		Users users = reqDto.toEntity();
+
+		given(usersService.signup(any(SignupReqDto.class))).willReturn(users);
+
+		// when
+		ResponseEntity<String> response = loginController.signup(reqDto);
+
+		// then
+		verify(usersService).signup(reqDto);//usersService.signup() 메소드가 호출되었는지 확인
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("성공적으로 가입되었습니다.", response.getBody());
+
+	}
+
+
+
+
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/UsersControllerTest.java
@@ -1,0 +1,144 @@
+package com.efub.lakkulakku.domain.users.controller;
+
+import com.efub.lakkulakku.domain.users.dao.CertificationDao;
+import com.efub.lakkulakku.domain.users.dto.LoginInfoDto;
+import com.efub.lakkulakku.domain.users.dto.LoginReqDto;
+import com.efub.lakkulakku.domain.users.dto.SignupReqDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.domain.users.service.CustomUsersDetailsService;
+import com.efub.lakkulakku.domain.users.service.MailSendService;
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import com.efub.lakkulakku.global.config.TestUsers;
+import com.efub.lakkulakku.global.config.WithUserDetailsSecurityContextFactory;
+import com.efub.lakkulakku.global.config.jwt.JwtProvider;
+import com.efub.lakkulakku.global.redis.RedisService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.is;
+
+
+@WebMvcTest({LoginController.class})//웹 계층 테스트를 위한 어노테이션
+@ExtendWith(MockitoExtension.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class UsersControllerTest {
+	@MockBean//스프링 컨텍스트의 빈을 대체하는 목 객체를 만든다. 애플리케이션 컨텍스트에 빈으로 등록되어 다른 빈에서 주입 받을 수 있음
+	UsersService usersService;
+
+	@MockBean
+	UsersRepository usersRepository;
+
+	@MockBean
+	MailSendService mailSendService;
+	@MockBean
+	CertificationDao certificationDao;
+
+
+/*	@MockBean
+	CustomUsersDetailsService customUsersDetailsService;*/
+
+
+	@MockBean
+	private RedisTemplate<String, String> redisTemplate;
+
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+
+	@Test
+	@WithMockUser
+	@DisplayName("회원가입_성공")
+	void signUp() throws Exception {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test12";
+
+		final SignupReqDto reqDto = SignupReqDto.builder()
+				.email(email)
+				.password(password)
+				.nickname(nickname)
+				.build();
+
+		Users users = reqDto.toEntity();
+
+		given(usersService.signup(any(SignupReqDto.class))).willReturn(users);
+
+		//when
+
+		ResultActions perform = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/signup")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(new ObjectMapper().writeValueAsString(reqDto))
+						.with(csrf())); //403 에러로 인해 추가
+		//then
+		perform
+				.andExpect(status().isCreated());//자원 생성이므로 변경
+
+		//verify(usersService).signup(reqDto);
+	}
+
+/*	@Test
+	@TestUsers
+	@DisplayName("로그인_성공")
+	void login() throws Exception {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		LoginReqDto loginReqDto = LoginReqDto
+				.builder()
+				.email(email)
+				.password(password)
+				.build();
+		LoginInfoDto loginInfoDto = LoginInfoDto.builder()
+				.accessToken("test_access_token")
+				.refreshToken("test_refresh_token")
+				.build();
+
+		given(usersService.login(email, password)).willReturn(loginInfoDto);
+
+
+		ResultActions perform = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(loginReqDto))
+				.with(csrf()));
+		perform.andExpect(status().isCreated())
+				.andExpect((ResultMatcher) jsonPath("$.accessToken", is("test_access_token")))
+				.andExpect((ResultMatcher) jsonPath("$.refreshToken", is("test_refresh_token")))
+				.andExpect(header().string("Set-Cookie", containsString("refreshToken=test_refresh_token;")));
+
+		verify(usersService).login(email, password);
+
+	}*/
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/UsersControllerTest.java
@@ -90,7 +90,6 @@ public class UsersControllerTest {
 		given(usersService.signup(any(SignupReqDto.class))).willReturn(users);
 
 		//when
-
 		ResultActions perform = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/signup")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(new ObjectMapper().writeValueAsString(reqDto)).content(new ObjectMapper().writeValueAsString(reqDto))

--- a/src/test/java/com/efub/lakkulakku/domain/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/controller/UsersControllerTest.java
@@ -68,8 +68,6 @@ public class UsersControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 
-
-
 	@Test
 	@WithMockUser
 	@DisplayName("회원가입_성공")
@@ -155,7 +153,6 @@ public class UsersControllerTest {
 				"; Secure; HttpOnly; SameSite=None";
 
 		assertThat(mvcResult.getResponse().getHeader(HttpHeaders.SET_COOKIE)).isEqualTo(expectedCookieValue);
-
 	}
 
 

--- a/src/test/java/com/efub/lakkulakku/domain/users/entity/UsersTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/entity/UsersTest.java
@@ -1,0 +1,34 @@
+package com.efub.lakkulakku.domain.users.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+//순수한 도메인 로직의 경우 Junit이나 AssetJ 등 테스트 편의 도구외의 다른 프레임 워크의 도움이 필요하지 않는다.
+@ExtendWith(SpringExtension.class) //Junit4의 Runwith과 같은 기능을 하는 Junit5 어노테이션
+class UsersTest {
+
+	@Test
+	@DisplayName("계정 생성 테스트")
+	void createUsers() {
+		final String email = "test@gmail";
+		final String nickname = "테스트계정";
+		final String encodedPassword = "encodedPassoword";
+
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password(encodedPassword)
+				.build();
+
+		assertThat(user.getEmail()).isEqualTo(email);
+		assertThat(user.getNickname()).isEqualTo(nickname);
+		assertThat(user.getPassword()).isEqualTo(encodedPassword);
+
+	}
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/repository/UsersRepositoryTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/repository/UsersRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.efub.lakkulakku.domain.users.repository;
+
+import com.efub.lakkulakku.domain.users.entity.Users;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 테스트에서 사용할 데이터베이스를 지정하는 어노테이션, 실제 DB 사용
+public class UsersRepositoryTest {
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Autowired
+	private UsersRepository usersRepository;
+
+	@Test
+	@DisplayName("findByEmail_성공")
+	void findByEmail() {
+		// given
+		String email = "testtest@gmail.com";
+		String nickname = "testtest";
+		Users user = Users.builder()
+				.email(email)
+				.nickname(nickname)
+				.password("password")
+				.build();
+		entityManager.persist(user);
+
+		// when
+		Optional<Users> result = usersRepository.findByEmail(email);
+
+		// then
+		assertTrue(result.isPresent());
+		assertEquals(result.get().getNickname(), nickname);
+	}
+
+	@Test
+	@DisplayName("findByEmail_실패")
+	void findByEmailFailure() {
+		// given
+		String email = "testtttttttt@gmail.com";
+
+		// when
+		Optional<Users> result = usersRepository.findByEmail(email);
+
+		// then
+		assertFalse(result.isPresent());
+	}
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/service/LoginServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/service/LoginServiceTest.java
@@ -1,0 +1,129 @@
+package com.efub.lakkulakku.domain.users.service;
+
+import com.efub.lakkulakku.domain.friend.exception.UserNotFoundException;
+import com.efub.lakkulakku.domain.profile.ProfileRepository;
+import com.efub.lakkulakku.domain.profile.entity.Profile;
+import com.efub.lakkulakku.domain.users.dto.LoginInfoDto;
+import com.efub.lakkulakku.domain.users.dto.LoginReqDto;
+import com.efub.lakkulakku.domain.users.dto.SignupReqDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.exception.PasswordNotMatchedException;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.global.config.jwt.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class LoginServiceTest {
+
+	@InjectMocks // 실제 객체로 생성되며, @Mock이 붙은 객체를 주입 받습니다.
+	UsersService usersService;
+
+	@Mock
+	UsersRepository usersRepository;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	@Mock
+	JwtProvider jwtProvider;
+
+	@Test
+	@DisplayName("로그인_성공")
+	void login() {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test";
+		String accessToken = "accessToken";
+		String refreshToken = "refreshToken";
+
+		LoginReqDto loginReqDto = LoginReqDto
+				.builder()
+				.email(email)
+				.password(password)
+				.build();
+		Users users = Users.builder()
+				.nickname(nickname)
+				.email(email)
+				.password(password)
+				.build();
+
+		given(usersRepository.findByEmail(loginReqDto.getEmail())).willReturn(Optional.of(users));
+		given(jwtProvider.createAccessToken(loginReqDto.getEmail(), users.getRole())).willReturn(accessToken);
+		given(jwtProvider.createRefreshToken(loginReqDto.getEmail(), users.getRole())).willReturn(refreshToken);
+		given(passwordEncoder.matches(password, password)).willReturn(true);
+
+		//when
+		LoginInfoDto result = usersService.login(email, password);
+
+		//then
+		assertEquals(accessToken, result.getAccessToken());
+		assertEquals(refreshToken, result.getRefreshToken());
+		assertEquals(nickname, result.getNickname());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 이메일로 로그인 테스트")
+	void loginByInvalidEmail() {
+		String email = "test1234@gmail.com";
+		String wrongEmail = "worng@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test";
+		LoginReqDto loginReqDto = LoginReqDto
+				.builder()
+				.email(wrongEmail)
+				.password(password)
+				.build();
+		Users users = Users.builder()
+				.nickname(nickname)
+				.email(email)
+				.password(password)
+				.build();
+		given(usersRepository.findByEmail(loginReqDto.getEmail())).willThrow(new UserNotFoundException());
+
+		assertThrows(UserNotFoundException.class, () -> usersService.login(loginReqDto.getEmail(), loginReqDto.getPassword()));
+	}
+
+	@Test
+	@DisplayName("비밀번호_불일치_로그인_실패")
+	void loginByInvalidPassword() {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String wrongPassword = "wrong!!";
+		String nickname = "test";
+		LoginReqDto loginReqDto = LoginReqDto
+				.builder()
+				.email(email)
+				.password(wrongPassword)
+				.build();
+		Users users = Users.builder()
+				.nickname(nickname)
+				.email(email)
+				.password(password)
+				.build();
+		given(usersRepository.findByEmail(loginReqDto.getEmail())).willReturn(Optional.of(users));
+
+		//when
+		assertThrows(PasswordNotMatchedException.class, () -> usersService.login(loginReqDto.getEmail(), loginReqDto.getPassword()));
+	}
+
+
+
+
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/service/SignUpServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/service/SignUpServiceTest.java
@@ -43,15 +43,16 @@ class SignUpServiceTest {
 		String password = "test1234!!";
 		String nickname = "test";
 		String bio = "반갑습니다 :)";
+		UUID id = UUID.randomUUID();
+
 		final SignupReqDto signupReqDto = SignupReqDto.builder()
 				.email(email)
 				.password(password)
 				.nickname(nickname)
 				.build();
 		Users users = signupReqDto.toEntity();
+		users.setUserIdForTest(id);
 		users.setPassword(encodePassword(signupReqDto.getPassword()));
-		UUID id = UUID.randomUUID();
-		users.setId(id);
 
 		Profile profile = Profile.builder()
 				.file(null)
@@ -68,7 +69,7 @@ class SignUpServiceTest {
 		Users users1 = usersService.signup(signupReqDto);
 
 		// then
-		Users findUsers = usersRepository.findById(users1.getId()).get();
+		Users findUsers = usersRepository.findById(users1.getUserId()).get();
 		assertEquals(users.getEmail(), findUsers.getEmail());
 		assertEquals(users.getNickname(), findUsers.getNickname());
 		assertEquals(users.getPassword(), findUsers.getPassword());

--- a/src/test/java/com/efub/lakkulakku/domain/users/service/SignUpServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/service/SignUpServiceTest.java
@@ -1,0 +1,82 @@
+package com.efub.lakkulakku.domain.users.service;
+
+import com.efub.lakkulakku.domain.profile.ProfileRepository;
+import com.efub.lakkulakku.domain.profile.entity.Profile;
+import com.efub.lakkulakku.domain.users.dto.SignupReqDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class SignUpServiceTest {
+
+	@InjectMocks // 실제 객체로 생성되며, @Mock이 붙은 객체를 주입 받습니다.
+	UsersService usersService;
+
+	@Mock
+	UsersRepository usersRepository;
+	@Mock
+	ProfileRepository profileRepository;
+
+	@Spy // Mock하지 않은 메소드는 실제 메소드로 동작
+	private BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+	@Test
+	@DisplayName("회원가입 테스트_성공")
+	void signUpUsersService() {
+		//given
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test";
+		String bio = "반갑습니다 :)";
+		final SignupReqDto signupReqDto = SignupReqDto.builder()
+				.email(email)
+				.password(password)
+				.nickname(nickname)
+				.build();
+		Users users = signupReqDto.toEntity();
+		users.setPassword(encodePassword(signupReqDto.getPassword()));
+		UUID id = UUID.randomUUID();
+		users.setId(id);
+
+		Profile profile = Profile.builder()
+				.file(null)
+				.users(users)
+				.bio(bio)
+				.build();
+		users.setProfile(profile);
+
+		given(usersRepository.save(any(Users.class))).willReturn(users);
+		given(usersRepository.findById(id)).willReturn(Optional.of(users));
+
+
+		// when
+		Users users1 = usersService.signup(signupReqDto);
+
+		// then
+		Users findUsers = usersRepository.findById(users1.getId()).get();
+		assertEquals(users.getEmail(), findUsers.getEmail());
+		assertEquals(users.getNickname(), findUsers.getNickname());
+		assertEquals(users.getPassword(), findUsers.getPassword());
+
+	}
+
+
+	private String encodePassword(String password) {
+		return passwordEncoder.encode(password);
+	}
+}

--- a/src/test/java/com/efub/lakkulakku/domain/users/service/SignUpServiceTest.java
+++ b/src/test/java/com/efub/lakkulakku/domain/users/service/SignUpServiceTest.java
@@ -58,7 +58,7 @@ class SignUpServiceTest {
 				.users(users)
 				.bio(bio)
 				.build();
-		users.setProfile(profile);
+		//users.setProfile(profile);
 
 		given(usersRepository.save(any(Users.class))).willReturn(users);
 		given(usersRepository.findById(id)).willReturn(Optional.of(users));

--- a/src/test/java/com/efub/lakkulakku/global/config/AppConfigTest.java
+++ b/src/test/java/com/efub/lakkulakku/global/config/AppConfigTest.java
@@ -1,0 +1,13 @@
+package com.efub.lakkulakku.global.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class AppConfigTest {
+
+	@Test
+	void filterChain() {
+	}
+}

--- a/src/test/java/com/efub/lakkulakku/global/config/TestUsers.java
+++ b/src/test/java/com/efub/lakkulakku/global/config/TestUsers.java
@@ -1,0 +1,17 @@
+package com.efub.lakkulakku.global.config;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithUserDetailsSecurityContextFactory.class)
+public @interface TestUsers {
+	//@TestMember 애너테이션 값으로 전달된 사용자 정보를 사용하여 인증된 SecurityContext를 생성
+	//실제 서비스에서 @AuthUsers 커스텀 어노테이션으로 인증된 사용자의 정보를 가져오는 것과 비슷
+	String email() default "test1234@gmail.com";
+	String password() default "test1234!!";
+	String nickname() default "test";
+	String[] roles() default {"USER"};
+}

--- a/src/test/java/com/efub/lakkulakku/global/config/WithUserDetailsSecurityContextFactory.java
+++ b/src/test/java/com/efub/lakkulakku/global/config/WithUserDetailsSecurityContextFactory.java
@@ -6,7 +6,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.test.context.support.WithSecurityContext;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
 public class WithUserDetailsSecurityContextFactory implements WithSecurityContextFactory<TestUsers> {
@@ -23,6 +22,7 @@ public class WithUserDetailsSecurityContextFactory implements WithSecurityContex
 						.password(password)
 						.nickname(nickname)
 						.build();
+
 		UserDetails userAccount = new AuthUsers(users);
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(userAccount, "", userAccount.getAuthorities());
 		SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/src/test/java/com/efub/lakkulakku/global/config/WithUserDetailsSecurityContextFactory.java
+++ b/src/test/java/com/efub/lakkulakku/global/config/WithUserDetailsSecurityContextFactory.java
@@ -1,0 +1,32 @@
+package com.efub.lakkulakku.global.config;
+
+import com.efub.lakkulakku.domain.users.entity.AuthUsers;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithUserDetailsSecurityContextFactory implements WithSecurityContextFactory<TestUsers> {
+	//@WithSecurityContext 애노테이션으로 마킹된 테스트 메소드에서 Spring Security 인증에 필요한 SecurityContext를 생성하기 위한 메소드를 제공
+	//WithUserDetailsSecurityContextFactory 라는 팩토리 클래스를 사용하여 인증된 SecurityContext를 생성
+
+	@Override
+	public SecurityContext createSecurityContext(TestUsers annotation) {
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String nickname = "test";
+		Users users = Users.builder()
+						.email(email)
+						.password(password)
+						.nickname(nickname)
+						.build();
+		UserDetails userAccount = new AuthUsers(users);
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(userAccount, "", userAccount.getAuthorities());
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		context.setAuthentication(token);
+		return context;
+	}
+}

--- a/src/test/java/com/efub/lakkulakku/global/config/jwt/JwtProviderTest.java
+++ b/src/test/java/com/efub/lakkulakku/global/config/jwt/JwtProviderTest.java
@@ -1,14 +1,76 @@
 package com.efub.lakkulakku.global.config.jwt;
 
+import com.efub.lakkulakku.domain.users.service.UsersService;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class JwtProviderTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@InjectMocks // 실제 객체로 생성되며, @Mock이 붙은 객체를 주입 받습니다.
+	JwtProvider jwtProvider;
+
+	private final String userId = "test123";
+	private final String roles = "USER";
+	private final Long tokenInvalidTime = 1000L * 60 * 120; // 2h
+
+	String SECRET_KEY = "secret-key";
+	@PostConstruct
+	protected void init() {
+		SECRET_KEY = Base64.getEncoder().encodeToString(SECRET_KEY.getBytes());
+	}
+
+/*	@Test
+	public void shouldNotAllowAccessToUnauthenticatedUsers() throws Exception {
+		mvc.perform(MockMvcRequestBuilders.get("/test")).andExpect(status().isForbidden());
+	}*/
+
+
+	@Test
+	@DisplayName("accessToken생성_성공")
+	public void shouldGenerateAccessToken() throws Exception {
+		Long tokenInvalidTime = 1000L * 60 * 120; // 2h
+		String email = "test1234@gmail.com";
+		String password = "test1234!!";
+		String accessToken = "test_access_token";
+		String refreshToken = "test_refresh_token";
+
+		//final Long TOKEN_VALID_TIME = 1000L * 60 * 120; // 2h
+
+
+		given(jwtProvider.createToken(email, "USERS", tokenInvalidTime)).willReturn(refreshToken);
+		given(jwtProvider.createToken(email, "USERS", tokenInvalidTime)).willReturn(accessToken);
+
+		//then
+		String token = jwtProvider.createAccessToken("userId", "USERS");
+
+
+		assertNotNull(token);
+		assertEquals(userId, Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(accessToken).getBody().get("userId"));
+		assertEquals(roles, Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(accessToken).getBody().get("roles"));
+		//mvc.perform(MockMvcRequestBuilders.get("/test").header("Authorization", token)).andExpect(status().isOk());
+	}
+
+
 
 	@Test
 	void createAccessToken() {

--- a/src/test/java/com/efub/lakkulakku/global/config/jwt/JwtProviderTest.java
+++ b/src/test/java/com/efub/lakkulakku/global/config/jwt/JwtProviderTest.java
@@ -1,0 +1,20 @@
+package com.efub.lakkulakku.global.config.jwt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtProviderTest {
+
+	@Test
+	void createAccessToken() {
+	}
+
+	@Test
+	void createRefreshToken() {
+	}
+}


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->
Friend 레이어 간 구분

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- Friend 엔티티 변수명 명확성을 위해 targetId -> target으로 변경, userId -> sender로 변경
- Friend repository 메소드는 서비스 계층에서만 접근하도록 구분함
- Friend respository 메소드 중 객체가 아닌 id로 조회할 때 오류 수정
- Friend Service 내 target과 sender를 확인 시 중복 코드 개선

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->
